### PR TITLE
docs: align technical documentation with the current system

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,8 +33,8 @@ assignees: ''
 - **Platform:** [e.g., Web, Mobile]  
 - **OS:** [e.g., Windows, macOS, Linux]  
 - **Browser:** [e.g., Chrome, Firefox]  
-- **Backend:** [e.g., FastAPI, NestJS, Express]  
-- **Database:** [e.g., MongoDB]  
+- **Backend:** [Express. Note the version or the commit if relevant.]  
+- **Database:** [PostgreSQL. Note the version if relevant.]  
 
 **Screenshots (if applicable):**  
 [Attach screenshots or logs here.]  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Deployment & Infrastructure page documenting the Coolify topology, domains, build strategies and the complete
-  environment variable table
+- Deployment & Infrastructure page documenting the Cloudflare Tunnel and Coolify topology, domains, build
+  strategies, the environment variables read by the API, and the operational traps around `NODE_ENV`,
+  `S3_ENDPOINTS`, `CERTIFICATE_VERIFICATION_URL` and the Cloudflare 100 MB request body limit
 - Web Developer Handbook with a Getting Started guide for `educado-web`
 - Back End Getting Started guide, previously an empty stub, covering local infrastructure, environment setup, the
   email worker, tests and troubleshooting
@@ -25,11 +26,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   MinIO, Resend, Expo/EAS, Swagger, Jest)
 - Product Overview technical specifications corrected: Express 5 instead of NestJS, Vite instead of Vue.js, and
   self hosted Coolify deployment instead of generic public cloud
+- Tools & Dependencies no longer presents `axios` as the web HTTP client: the web app calls the in house `fetch`
+  wrapper in `src/shared/api/http.ts`, and `axios` is flagged as a declared but unused dependency. `flatpickr`
+  added, since it is actually used
+- System Architecture no longer claims `requireRole` standardises authorization: it guards the `/student` surface
+  only, while admin access is enforced per handler through `ensureAdminRole(role)`
+- API Documentation gained the multipart video part upload and the two student progress routes
+- Back End Getting Started no longer implies tests live only under `src/application`, and warns that `npm run dev`
+  uses inline env assignment, which fails in Windows `cmd` and PowerShell
+- Deployment: `PORT` marked optional, matching its `5000` default in `src/index.ts`, and `Coolify 4.3.1` marked as
+  a version observed on 2026-08-13
+- Web Getting Started now describes the real anatomy of each feature directory instead of a uniform shape that no
+  feature follows
+- Bug report issue template now names the actual stack (Express, PostgreSQL) instead of unrelated examples
+- Strapi evaluation: the "additional database" trade off no longer refers to MongoDB, and the architecture diagram
+  carries a notice that it is historical
 
 ### Removed
 
 - Content from an unrelated project in the System Architecture page (MongoDB, Vue.js, doctor and administrator
   domain models)
+
+  Scope note: this covers the System Architecture page only. MongoDB still appears elsewhere by design, in
+  `docs/assets/strapi/architecture.svg`, which is a historical artifact of the Strapi evaluation and is kept as
+  drawn, with a warning on the page that renders it.
 
 ## [2.6.2] - 2025-12-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - 2026-08-13
+
+### Added
+
+- Deployment & Infrastructure page documenting the Coolify topology, domains, build strategies and the complete
+  environment variable table
+- Web Developer Handbook with a Getting Started guide for `educado-web`
+- Back End Getting Started guide, previously an empty stub, covering local infrastructure, environment setup, the
+  email worker, tests and troubleshooting
+
+### Changed
+
+- System Architecture rewritten against the implemented system (PostgreSQL with Sequelize, Express 5, layered API,
+  Vite web app, Expo mobile app, BullMQ email pipeline, JWT role model)
+- API Documentation now uses the real base URL and the routers actually mounted by the application, with Swagger
+  pointed out as the canonical source
+- Tools & Dependencies now lists the toolchain in use (GitHub Actions, Coolify, Nixpacks, Docker, PostgreSQL, Redis,
+  MinIO, Resend, Expo/EAS, Swagger, Jest)
+- Product Overview technical specifications corrected: Express 5 instead of NestJS, Vite instead of Vue.js, and
+  self hosted Coolify deployment instead of generic public cloud
+
+### Removed
+
+- Content from an unrelated project in the System Architecture page (MongoDB, Vue.js, doctor and administrator
+  domain models)
+
 ## [2.6.2] - 2025-12-02
 ### Added
 - Added documentation for EAS Build and updating the app

--- a/docs/development/technical/api.md
+++ b/docs/development/technical/api.md
@@ -2,244 +2,228 @@
 
 [← Back to Main Page](../../index.md)
 
-This documentation provides a comprehensive overview of the API for managing users, courses, content, enrollment, media, notifications, and progress within the Educado platform.
+This page is a map of the Educado REST API: base URLs, authentication, and the routers that are actually mounted by
+the application.
 
----
+!!! important "Swagger is the canonical source"
+
+    The OpenAPI document lives in the API repository (`educado-api/src/docs/swagger.ts`) and is served by the API
+    itself. Request and response schemas, field names and status codes are authoritative there, not here.
+
+    - Deployed: [https://api-educado.tominho.com/docs/](https://api-educado.tominho.com/docs/)
+    - Local: `http://localhost:5001/docs/`
+
+    If this page and Swagger disagree, Swagger wins and this page is the bug.
 
 ## Base URL
 
-The base URL for all API requests is:
+| Environment | Base URL                                                           |
+| ----------- | ------------------------------------------------------------------ |
+| Production  | [https://api-educado.tominho.com](https://api-educado.tominho.com) |
+| Local       | `http://localhost:5001` (see `PORT` in the API `.env`)         |
 
+There is no `/api` prefix. Routers are mounted directly at the root, so a course listing is
+`GET https://api-educado.tominho.com/courses`.
 
-[https://api.educado.com](https://api.educado.com)
-
-
----
+The web application reads the base URL from `VITE_API_URL` at build time and falls back to `http://localhost:5001`.
 
 ## Authentication
 
-All requests requiring authentication must include a **Bearer token** in the `Authorization` header. The token is obtained after a successful login.
+Protected requests carry a JWT in the `Authorization` header:
 
-**Example:**
-
+```http
 Authorization: Bearer <your-jwt-token>
----
+```
 
-## Endpoints
+Tokens are issued by the login endpoints (`POST /auth/login`, `POST /user/login`, and the student login endpoints
+under `/student/auth`). The token payload carries the subject (`sub`) and the `role`, which is one of `ADMIN`,
+`STUDENT` or `USER` (content creator). Routes guard themselves with `requireAuth` and `requireRole`.
 
-### 1. **User Management**
+`GET /media/:id/stream` also accepts the token as a `token` query parameter so that `<img>` and `<video>` tags
+can load protected assets.
 
-| Endpoint          | Method   | Description                             |
-| ----------------- | -------- | --------------------------------------- |
-| `/api/register`   | `POST`   | Registers a new user (student/creator). |
-| `/api/login`      | `POST`   | Logs in a user and returns a JWT token. |
-| `/api/users`      | `GET`    | Lists all users (Admin only).           |
-| `/api/users/{id}` | `GET`    | Retrieves details of a user.            |
-| `/api/users/{id}` | `PUT`    | Edits a user profile.                   |
-| `/api/users/{id}` | `DELETE` | Deactivates a user (soft delete).       |
+Errors use machine readable codes, for example:
 
-#### 1.1 User Registration
+```json
+{ "code": "UNAUTHORIZED" }
+```
 
-* **URL:** `/api/register`
-* **Method:** `POST`
-* **Request Body:**
+## Mounted routers
 
-  ```json
-  {
-    "name": "Alice",
-    "email": "alice@example.com",
-    "password": "Password123",
-    "role": "student" or "creator"
-  }
-  ```
-* **Responses:**
+These are the routers mounted in `educado-api/src/index.ts`.
 
-  * **201 Created**
-  * **400 Bad Request**
+| Mount point                     | Purpose                                                                    |
+| ------------------------------- | -------------------------------------------------------------------------- |
+| `/user`                       | Legacy user login and identity lookup.                                     |
+| `/auth`                       | Creator registration, login and password reset.                            |
+| `/admin`                      | Administrative review of users, registrations and media.                   |
+| `/me`                         | Everything scoped to the authenticated user (profile, avatar, media).      |
+| `/courses`                    | Course CRUD and activation for creators and admins.                        |
+| `/sections`                   | Sections inside a course.                                                  |
+| `/activities`                 | Activities inside a section.                                               |
+| `/progress`                   | Progress records per user and course.                                      |
+| `/certificates`               | Certificate issuing, listing and public verification.                      |
+| `/tags`                       | Course tags.                                                               |
+| `/institutions`               | Partner institutions.                                                      |
+| `/account/email-verification` | Send and confirm the email verification code.                              |
+| `/media`                      | Image and video upload, metadata and streaming.                            |
+| `/student`                    | The mobile app surface (auth, profile, enrollments, progress, gamification). |
+| `/catalog`                    | Public course discovery.                                                   |
+| `/leaderboard`                | Global and per course rankings.                                            |
+| `/docs`                       | Swagger UI.                                                                |
 
-#### 1.2 User Login
+## Endpoint reference
 
-* **URL:** `/api/login`
-* **Method:** `POST`
-* **Request Body:**
+### Auth and users
 
-  ```json
-  {
-    "email": "alice@example.com",
-    "password": "Password123"
-  }
-  ```
-* **Responses:**
+| Endpoint                              | Method | Description                                     |
+| ------------------------------------- | ------ | ----------------------------------------------- |
+| `/auth/registrations`               | POST   | Submit a creator registration.                  |
+| `/auth/registrations/me/profile`    | PUT    | Update the profile of your own registration.    |
+| `/auth/registrations/:userId/profile` | PUT  | Update another registration profile (admin).    |
+| `/auth/registrations/me/status`     | GET    | Check the status of your registration.          |
+| `/auth/login`                       | POST   | Log in and receive a JWT.                       |
+| `/auth/password-reset/request`      | POST   | Request a reset code.                           |
+| `/auth/password-reset/verify`       | POST   | Verify the reset code.                          |
+| `/auth/password-reset/reset`        | POST   | Set the new password.                           |
+| `/user/login`                       | POST   | Legacy login.                                   |
+| `/user/me`                          | POST   | Resolve the current user.                       |
+| `/account/email-verification/send`    | POST   | Send an email verification code.                |
+| `/account/email-verification/confirm` | POST   | Confirm the code.                               |
 
-  * **200 OK**: `{ "token": "<jwt-token>" }`
-  * **401 Unauthorized**
+### Authenticated user (`/me`)
 
-#### 1.3 Get User List (Admin only)
+| Endpoint                     | Method | Description                          |
+| ---------------------------- | ------ | ------------------------------------ |
+| `/me/profile`              | GET    | Read your profile.                   |
+| `/me/profile`              | PUT    | Update your profile.                 |
+| `/me/avatar`               | PUT    | Set the avatar from a media asset.   |
+| `/me/avatar`               | DELETE | Remove the avatar.                   |
+| `/me/courses`              | GET    | Courses you own or are enrolled in.  |
+| `/me/media`                | GET    | Media assets you own.                |
+| `/me/password/request-code` | POST  | Request a password change code.      |
+| `/me/account`              | DELETE | Delete your own account.             |
 
-* **URL:** `/api/users`
-* **Method:** `GET`
-* **Response:** `[{ "_id": "...", "name": "...", "email": "...", "role": "student" }]`
+### Administration (`/admin`)
 
-#### 1.4 Get User Details
+| Endpoint                                | Method | Description                              |
+| --------------------------------------- | ------ | ---------------------------------------- |
+| `/admin/users`                        | GET    | List users.                              |
+| `/admin/users/:userId`                | GET    | User detail.                             |
+| `/admin/users/:userId/role`           | PATCH  | Change a user role.                      |
+| `/admin/users/:userId`                | DELETE | Remove a user.                           |
+| `/admin/registrations`                | GET    | List pending registrations.              |
+| `/admin/registrations/:userId/approve` | POST  | Approve a creator registration.          |
+| `/admin/registrations/:userId/reject` | POST   | Reject a creator registration.           |
+| `/admin/media`                        | GET    | List media across the platform.          |
 
-* **URL:** `/api/users/{id}`
-* **Method:** `GET`
-* **Response:** `{ "_id": "...", "name": "...", "email": "...", "role": "...", ... }`
+### Content
 
-#### 1.5 Edit User Profile
+| Endpoint                       | Method | Description                          |
+| ------------------------------ | ------ | ------------------------------------ |
+| `/courses`                   | GET    | List courses.                        |
+| `/courses`                   | POST   | Create a course.                     |
+| `/courses/:id`               | GET    | Course detail.                       |
+| `/courses/:id`               | PUT    | Update a course.                     |
+| `/courses/:id/activate`      | POST   | Publish a course.                    |
+| `/courses/:id/deactivate`    | POST   | Unpublish a course.                  |
+| `/courses/:id`               | DELETE | Delete a course.                     |
+| `/sections`                  | GET    | List sections.                       |
+| `/sections`                  | POST   | Create a section.                    |
+| `/sections/:id`              | GET    | Section detail.                      |
+| `/sections/:id`              | PUT    | Update a section.                    |
+| `/sections/:id`              | DELETE | Delete a section.                    |
+| `/activities/section/:sectionId` | GET | Activities of a section.            |
+| `/activities/:id`            | GET    | Activity detail.                     |
+| `/activities`                | POST   | Create an activity.                  |
+| `/activities/:id`            | PUT    | Update an activity.                  |
+| `/activities/:id`            | DELETE | Delete an activity.                  |
+| `/tags`                      | GET    | List tags.                           |
+| `/tags/:id`                  | GET    | Tag detail.                          |
+| `/tags`                      | POST   | Create a tag.                        |
+| `/tags/:id`                  | PUT    | Update a tag.                        |
+| `/tags/:id`                  | DELETE | Delete a tag.                        |
+| `/institutions`              | GET    | List institutions.                   |
+| `/institutions/:id`          | GET    | Institution detail.                  |
+| `/institutions`              | POST   | Create an institution.               |
+| `/institutions/:id`          | PUT    | Update an institution.               |
+| `/institutions/:id`          | DELETE | Delete an institution.               |
 
-* **URL:** `/api/users/{id}`
-* **Method:** `PUT`
-* **Request Body:**
+### Catalog and leaderboard
 
-  ```json
-  {
-    "name": "Alice Updated",
-    "email": "alice.updated@example.com"
-  }
-  ```
-* **Response:** `{ "message": "User updated successfully", "user": { ... } }`
+| Endpoint                          | Method | Description                         |
+| --------------------------------- | ------ | ----------------------------------- |
+| `/catalog/courses`              | GET    | Browse the published catalog.       |
+| `/catalog/courses/:id`          | GET    | Public course detail.               |
+| `/catalog/courses/:id/reviews`  | GET    | Reviews of a course.                |
+| `/catalog/categories`           | GET    | Catalog categories.                 |
+| `/leaderboard/global`           | GET    | Global ranking.                     |
+| `/leaderboard/courses/:courseId` | GET   | Ranking within a course.            |
 
-#### 1.6 Deactivate User
+### Student surface (`/student`)
 
-* **URL:** `/api/users/{id}`
-* **Method:** `DELETE`
-* **Response:** `{ "message": "User deactivated successfully" }`
+| Endpoint                                  | Method | Description                              |
+| ----------------------------------------- | ------ | ---------------------------------------- |
+| `/student/auth/register`                | POST   | Register a student.                      |
+| `/student/auth/device-login`            | POST   | Log in with a device identifier.         |
+| `/student/auth/phone-login`             | POST   | Log in with a phone number.              |
+| `/student/auth/email-login`             | POST   | Log in with email and password.          |
+| `/student/profile`                      | GET    | Student profile.                         |
+| `/student/profile`                      | PUT    | Update the student profile.              |
+| `/student/account`                      | DELETE | Delete the student account.              |
+| `/student/enrollments`                  | POST   | Enroll in a course.                      |
+| `/student/enrollments`                  | GET    | List enrollments.                        |
+| `/student/enrollments/:courseId`        | GET    | Enrollment detail.                       |
+| `/student/enrollments/:courseId`        | DELETE | Cancel an enrollment.                    |
+| `/student/progress/courses`             | GET    | Progress across courses.                 |
+| `/student/progress/courses/:courseId`   | GET    | Progress in one course.                  |
+| `/student/activities/:activityId/answer` | POST  | Submit an activity answer.               |
+| `/student/gamification/summary`         | GET    | Points, streak and level summary.        |
+| `/student/gamification/badges`          | GET    | Badges earned.                           |
+| `/student/gamification/points-history`  | GET    | Points ledger.                           |
+| `/student/reviews`                      | POST   | Review a course.                         |
+| `/student/reviews/check/:courseId`      | GET    | Whether the course was already reviewed. |
+| `/student/certificates`                 | GET    | Certificates earned.                     |
+| `/student/certificates/:id/pdf`         | GET    | Download a certificate as PDF.           |
 
----
+### Progress and certificates (creator/admin view)
 
-### 2. **Course Management**
+| Endpoint                                                       | Method | Description                       |
+| -------------------------------------------------------------- | ------ | --------------------------------- |
+| `/progress/:username/courses`                                | GET    | Progress records of a user.       |
+| `/progress/:username/courses/:courseId`                      | GET    | Progress in one course.           |
+| `/progress/:username/courses/:courseId/sections/:sectionId`  | POST   | Record section progress.          |
+| `/progress/:username/courses/:courseId/complete`             | PUT    | Mark a course as complete.        |
+| `/certificates/:username`                                    | GET    | Certificates of a user.           |
+| `/certificates`                                              | POST   | Issue a certificate.              |
+| `/certificates/verify/:code`                                 | GET    | Public certificate verification.  |
 
-| Endpoint            | Method   | Description                           |
-| ------------------- | -------- | ------------------------------------- |
-| `/api/courses`      | `POST`   | Creates a new course (creator/admin). |
-| `/api/courses`      | `GET`    | Lists all courses.                    |
-| `/api/courses/{id}` | `GET`    | Gets course details.                  |
-| `/api/courses/{id}` | `PUT`    | Updates a course.                     |
-| `/api/courses/{id}` | `DELETE` | Deactivates a course (soft delete).   |
+### Media (`/media`)
 
-#### 2.1 Create Course
-
-* **URL:** `/api/courses`
-* **Method:** `POST`
-* **Request Body:**
-
-  ```json
-  {
-    "title": "Waste Sorting Basics",
-    "description": "Learn how to separate waste.",
-    "creator_id": "uuid-of-creator"
-  }
-  ```
-* **Response:** `{ "message": "Course created successfully", "course": { ... } }`
-
-#### 2.2 List Courses
-
-* **URL:** `/api/courses`
-* **Method:** `GET`
-* **Response:** `[ { "_id": "...", "title": "...", ... } ]`
-
-#### 2.3 Course Details
-
-* **URL:** `/api/courses/{id}`
-* **Method:** `GET`
-* **Response:** `{ "_id": "...", "title": "...", ... }`
-
-#### 2.4 Update Course
-
-* **URL:** `/api/courses/{id}`
-* **Method:** `PUT`
-* **Request Body:**
-
-  ```json
-  {
-    "title": "Updated Course Title",
-    "description": "New description."
-  }
-  ```
-* **Response:** `{ "message": "Course updated successfully", "course": { ... } }`
-
-#### 2.5 Deactivate Course
-
-* **URL:** `/api/courses/{id}`
-* **Method:** `DELETE`
-* **Response:** `{ "message": "Course deactivated successfully" }`
-
----
-
-### 3. **Module, Lesson, and Exercise Management**
-
-| Endpoint                            | Method   | Description                      |
-| ----------------------------------- | -------- | -------------------------------- |
-| `/api/courses/{courseId}/modules`   | `POST`   | Creates a module in a course.    |
-| `/api/modules/{id}`                 | `PUT`    | Updates a module.                |
-| `/api/modules/{id}`                 | `DELETE` | Deactivates a module.            |
-| `/api/modules/{moduleId}/lessons`   | `POST`   | Creates a lesson in a module.    |
-| `/api/lessons/{id}`                 | `PUT`    | Updates a lesson.                |
-| `/api/lessons/{id}`                 | `DELETE` | Deactivates a lesson.            |
-| `/api/lessons/{lessonId}/exercises` | `POST`   | Creates an exercise in a lesson. |
-| `/api/exercises/{id}`               | `PUT`    | Updates an exercise.             |
-| `/api/exercises/{id}`               | `DELETE` | Deactivates an exercise.         |
-
----
-
-### 4. **Enrollment**
-
-| Endpoint                         | Method   | Description                                 |
-| -------------------------------- | -------- | ------------------------------------------- |
-| `/api/courses/{courseId}/enroll` | `POST`   | Enrolls the authenticated user in a course. |
-| `/api/enrollments`               | `GET`    | Lists enrollments for authenticated user.   |
-| `/api/enrollments/{id}`          | `DELETE` | Cancels an enrollment (soft delete).        |
-
----
-
-### 5. **Progress Tracking**
-
-| Endpoint        | Method | Description                                        |
-| --------------- | ------ | -------------------------------------------------- |
-| `/api/progress` | `GET`  | Lists progress records for the authenticated user. |
-| `/api/progress` | `POST` | Updates or creates a progress record.              |
-
----
-
-### 6. **Media Management**
-
-| Endpoint                  | Method   | Description                          |
-| ------------------------- | -------- | ------------------------------------ |
-| `/api/media`              | `POST`   | Uploads media (image, video, audio). |
-| `/api/media`              | `GET`    | Lists all media for the user.        |
-| `/api/media/{id}`         | `GET`    | Gets media details.                  |
-| `/api/media/{id}`         | `PUT`    | Updates media metadata.              |
-| `/api/media/{id}`         | `DELETE` | Deletes (deactivates) media.         |
-| `/api/courses/{id}/media` | `POST`   | Associates media to a course.        |
-| `/api/courses/{id}/media` | `DELETE` | Removes media from a course.         |
-
----
-
-### 7. **Notifications**
-
-| Endpoint                  | Method   | Description                       |
-| ------------------------- | -------- | --------------------------------- |
-| `/api/notifications`      | `POST`   | Creates a notification.           |
-| `/api/notifications`      | `GET`    | Lists notifications for the user. |
-| `/api/notifications/{id}` | `PUT`    | Updates a notification.           |
-| `/api/notifications/{id}` | `DELETE` | Deletes a notification.           |
-
----
+| Endpoint                       | Method | Description                                   |
+| ------------------------------ | ------ | --------------------------------------------- |
+| `/media/images`              | POST   | Upload an image.                              |
+| `/media/images/:id`          | GET    | Image metadata and access.                    |
+| `/media/images/:id/metadata` | POST / PUT | Update image metadata.                    |
+| `/media/images/:id`          | DELETE | Delete an image.                              |
+| `/media/videos`              | POST   | Upload a video.                               |
+| `/media/videos/init`         | POST   | Start a multipart video upload.               |
+| `/media/videos/:id/complete` | POST   | Complete a multipart upload.                  |
+| `/media/videos/:id/abort`    | POST   | Abort a multipart upload.                     |
+| `/media/videos/:id`          | GET    | Video metadata and access.                    |
+| `/media/videos/:id/metadata` | POST / PUT | Update video metadata.                    |
+| `/media/videos/:id`          | DELETE | Delete a video.                               |
+| `/media/:id/stream`          | GET    | Stream an asset, token accepted in the query. |
 
 ## Response Codes
 
-* `200 OK` – Request succeeded.
-* `201 Created` – Resource created successfully.
-* `400 Bad Request` – Invalid input.
-* `401 Unauthorized` – Authentication required or failed.
-* `403 Forbidden` – Insufficient permissions.
-* `404 Not Found` – Resource not found.
-* `409 Conflict` – Resource conflict (e.g., duplicate email).
-* `500 Internal Server Error` – Unhandled error.
-
----
-
-For further details on request/response formats, refer to the **OpenAPI/Swagger** specification.
+- `200 OK`: request succeeded.
+- `201 Created`: resource created successfully.
+- `400 Bad Request`: invalid input.
+- `401 Unauthorized`: authentication required or failed.
+- `403 Forbidden`: insufficient permissions.
+- `404 Not Found`: resource not found.
+- `409 Conflict`: resource conflict (for example, duplicate email).
+- `500 Internal Server Error`: unhandled error.
 
 [← Back to Main Page](../../index.md)

--- a/docs/development/technical/api.md
+++ b/docs/development/technical/api.md
@@ -177,6 +177,8 @@ These are the routers mounted in `educado-api/src/index.ts`.
 | `/student/enrollments/:courseId`        | DELETE | Cancel an enrollment.                    |
 | `/student/progress/courses`             | GET    | Progress across courses.                 |
 | `/student/progress/courses/:courseId`   | GET    | Progress in one course.                  |
+| `/student/progress/courses/:courseId/sections/:sectionId` | POST | Record progress on one section. |
+| `/student/progress/courses/:courseId/complete` | PUT | Mark the course as complete for the authenticated student. |
 | `/student/activities/:activityId/answer` | POST  | Submit an activity answer.               |
 | `/student/gamification/summary`         | GET    | Points, streak and level summary.        |
 | `/student/gamification/badges`          | GET    | Badges earned.                           |
@@ -206,14 +208,26 @@ These are the routers mounted in `educado-api/src/index.ts`.
 | `/media/images/:id`          | GET    | Image metadata and access.                    |
 | `/media/images/:id/metadata` | POST / PUT | Update image metadata.                    |
 | `/media/images/:id`          | DELETE | Delete an image.                              |
-| `/media/videos`              | POST   | Upload a video.                               |
+| `/media/videos`              | POST   | Upload a video in a single request. Legacy, kept for backward compatibility. |
 | `/media/videos/init`         | POST   | Start a multipart video upload.               |
+| `/media/videos/:id/parts/:partNumber` | POST | Upload one part of a multipart upload. Field name `chunk`, `partNumber` starts at 1. |
 | `/media/videos/:id/complete` | POST   | Complete a multipart upload.                  |
 | `/media/videos/:id/abort`    | POST   | Abort a multipart upload.                     |
 | `/media/videos/:id`          | GET    | Video metadata and access.                    |
 | `/media/videos/:id/metadata` | POST / PUT | Update video metadata.                    |
 | `/media/videos/:id`          | DELETE | Delete a video.                               |
 | `/media/:id/stream`          | GET    | Stream an asset, token accepted in the query. |
+
+!!! note "Video upload is a three call sequence"
+
+    `POST /media/videos/init` only opens the multipart upload; it moves no bytes. The actual content is sent by
+    `POST /media/videos/:id/parts/:partNumber`, once per chunk, as `multipart/form-data` with the file under the
+    field name `chunk`. `POST /media/videos/:id/complete` then assembles the parts, and
+    `POST /media/videos/:id/abort` discards them.
+
+    Parts are capped at 60 MB server side, sized for a 50 MB client chunk plus framing overhead. Prefer this flow
+    over the single request `POST /media/videos`, which is bounded by the 100 MB body limit imposed by Cloudflare in
+    front of the API. See [Deployment & Infrastructure](deployment.md).
 
 ## Response Codes
 

--- a/docs/development/technical/architecture.md
+++ b/docs/development/technical/architecture.md
@@ -1,161 +1,196 @@
-# Architecture
+# System Architecture
 
 [← Back to Main Page](../../index.md)
 
 ## Introduction
 
-This architecture document outlines the structure and core components of the content and user management system, focusing on the features and requirements defined in the project backlog. The architecture is designed to be scalable, modular, and easy to maintain, aiming to meet the MVP's needs and evolve as the product grows.
+This document describes the architecture of the Educado platform as it is actually implemented today. It covers the
+three applications (API, web, mobile), the data stores, the asynchronous email pipeline and the security model.
+
+Related documents:
+
+- [API Documentation](api.md) for the HTTP surface.
+- [Database Schema](database-schema.md) for the relational model.
+- [Deployment & Infrastructure](deployment.md) for the runtime topology and environment variables.
+- [Tools & Dependencies](../tools.md) for the toolchain.
 
 ## System Overview
 
-The system's primary goal is to enable the management of users and content for doctors and administrators, including user registration, authentication, profile management, and document and subscription management.
+Educado is a gamified learning platform for waste pickers in Brazil. Students consume courses on the mobile app,
+content creators build and manage courses on the web application, and administrators review creator registrations and
+govern the catalog. Everything is served by a single REST API.
 
-### **Technologies Used**
+| Application | Repository      | Stack                                        | Audience            |
+| ----------- | --------------- | -------------------------------------------- | ------------------- |
+| API         | `educado-api` | Node.js 20, Express 5, TypeScript, Sequelize | All clients         |
+| Web         | `educado-web` | Vite, TypeScript (no UI framework), nginx    | Creators and admins |
+| Mobile      | `educado-app` | Expo SDK 56, React Native, Android first     | Students            |
 
-| Technology         | Description                                                |
-| ------------------ | ---------------------------------------------------------- |
-| **Backend**        | Node.js with Express                                       |
-| **Database**       | MongoDB (for storing user and content data)                |
-| **Authentication** | JWT (JSON Web Tokens) for authentication and authorization |
-| **Frontend**       | Vue.js (for the admin interface)                           |
-| **Notifications**  | Service Worker and Firebase for push notifications         |
+Public environments:
+
+| Environment | URL                                                                              |
+| ----------- | -------------------------------------------------------------------------------- |
+| API         | [https://api-educado.tominho.com](https://api-educado.tominho.com)               |
+| Swagger UI  | [https://api-educado.tominho.com/docs/](https://api-educado.tominho.com/docs/)   |
+| Web         | [https://educado.tominho.com](https://educado.tominho.com)                       |
+
+### Technologies Used
+
+| Concern                 | Technology                                                    |
+| ----------------------- | ------------------------------------------------------------- |
+| **Runtime**             | Node.js 20 (`engines.node >= 20`)                           |
+| **HTTP framework**      | Express 5                                                     |
+| **Language**            | TypeScript 5.9 across API, web and mobile                     |
+| **Database**            | PostgreSQL 16 accessed through Sequelize 6                    |
+| **Cache and queue**     | Redis 7.2 with BullMQ 5 (email queue)                         |
+| **Object storage**      | MinIO, S3 compatible, driven by the AWS SDK v3 client         |
+| **Transactional email** | Resend                                                        |
+| **Authentication**      | JWT (`jsonwebtoken`), passwords hashed with bcryptjs        |
+| **API docs**            | Swagger UI served by the API itself at `/docs/`             |
+| **Web build**           | Vite 7, served in production by nginx                         |
+| **Mobile**              | Expo SDK 56 with `expo-router`, React Native 0.85           |
+
+!!! note
+
+    The web application is plain TypeScript with a small hand written router (`src/app/router.ts`). There is no Vue,
+    React or Angular in `educado-web`. React Native is used only in the mobile app.
 
 ## Component Architecture
 
-### 1. **User Management (EP01)**
-
-Responsible for creating, editing, deleting, and authenticating users (doctors and administrators). Key features include:
-
-| Feature                             | Description                                                                                     |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------- |
-| **User Registration (F01)**         | Creating accounts for doctors and administrators.                                               |
-| **Login (F05)**                     | Authenticating users with credentials and generating a JWT token.                               |
-| **Profile Editing (F04)**           | Allowing users to edit their profile, such as resetting passwords or updating personal details. |
-| **User Search and Listing (F02)**   | Administrators can search and list registered users.                                            |
-| **User Editing and Deletion (F03)** | Functionality for managing registered users, correcting or removing incorrect data.             |
-
-### 2. **Content Management (EP01)**
-
-Involves creating and managing documents, topics, and materials accessed by users.
-
-| Feature                                 | Description                                                     |
-| --------------------------------------- | --------------------------------------------------------------- |
-| **Document Creation and Listing (F06)** | Administrators can create new documents and view existing ones. |
-| **Document Editing and Deletion (F07)** | Functionality to update or remove outdated documents.           |
-| **Topics (F06)**                        | Allows for creating and listing topics related to documents.    |
-
-### 3. **Subscription and Notifications Management (EP02)**
-
-Responsible for managing doctors' subscriptions and sending notifications.
-
-| Feature                           | Description                                                                 |
-| --------------------------------- | --------------------------------------------------------------------------- |
-| **Subscription Management (F12)** | Allows doctors to access their financial area to manage their subscription. |
-
-### 4. **Authentication and Authorization**
-
-Authentication will be handled using JWT. Upon logging in, a user will receive a token granting access to the system's functionalities. Tokens will be validated to ensure that the user is authorized to access requested data and resources.
-
-### 5. **Architecture Layers**
-
-The architecture follows the MVC (Model-View-Controller) pattern:
-
-| Layer          | Description                                                                                                                          |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| **Model**      | Represents the data structure. User and document models are stored in the MongoDB database.                                          |
-| **View**       | The user interface, built with Vue.js, displays information and interacts with the user to capture data.                             |
-| **Controller** | Manages business logic and interacts with the models. Example: The user controller manages registration, login, and profile editing. |
-
-### 6. **Data Flow and Frontend Integration**
-
-The data flow follows a RESTful structure. The frontend application built with Vue.js makes calls to the backend REST APIs (Node.js + Express). The backend interacts with the MongoDB database to read and write data.
-
-#### Example Endpoints:
-
-| HTTP Method | Endpoint            | Description                                  |
-| ----------- | ------------------- | -------------------------------------------- |
-| `POST`    | `/api/register`   | Create a new user (doctor or administrator). |
-| `POST`    | `/api/login`      | User login.                                  |
-| `GET`     | `/api/users`      | List users (admin only).                     |
-| `PUT`     | `/api/users/{id}` | Edit user.                                   |
-| `DELETE`  | `/api/users/{id}` | Delete user.                                 |
-
-### 7. **Security**
-
-Security is a priority to ensure that only authenticated and authorized users can access sensitive data.
-
-| Security Feature   | Description                                                                                                                                   |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Encryption**     | Passwords will be securely stored using the bcrypt hashing algorithm.                                                                         |
-| **JWT Tokens**     | Authentication will be managed with JWT tokens, which will have an expiration time, requiring users to log in again after a certain period.   |
-| **Access Control** | The system will allow different levels of access, with only administrators able to perform user and document creation, editing, and deletion. |
-
-## Data Models
-
-### User Model
-
-```json
-{
-  "_id": "objectId",
-  "name": "string",
-  "email": "string",
-  "password": "string",
-  "role": "doctor | administrator",
-  "registrationDate": "date",
-  "status": "active | inactive"
-}
+```text
+          educado-app (Expo / RN)        educado-web (Vite + nginx)
+                     |                              |
+                     +------- HTTPS / JWT ----------+
+                                   |
+                                   v
+                     +-----------------------------+
+                     |    educado-api (Express)    |
+                     | routes -> application ->    |
+                     | domain / infrastructure     |
+                     +--+-----------+-----------+--+
+                        |           |           |
+              +---------v--+   +----v----+   +--v------------+
+              | PostgreSQL |   | Redis 7 |   | MinIO (S3)    |
+              | Sequelize  |   | BullMQ  |   | media assets  |
+              +------------+   +----+----+   +---------------+
+                                    |
+                          +---------v---------+
+                          | email worker      |
+                          | Resend            |
+                          +-------------------+
 ```
 
-### Document Model
+### API layering
 
-```json
-{
-  "_id": "objectId",
-  "title": "string",
-  "content": "string",
-  "topics": ["objectId"],
-  "creationDate": "date",
-  "updateDate": "date",
-  "status": "active | inactive"
-}
-```
+The API source tree in `educado-api/src` is organised in layers rather than a flat MVC:
 
-### Topic Model
+| Directory           | Responsibility                                                                                     |
+| ------------------- | -------------------------------------------------------------------------------------------------- |
+| `routes/`         | Express routers, one directory per resource. Request parsing and HTTP status mapping only.          |
+| `application/`    | Use cases (registration, catalog, enrollment, gamification, media, email, tags and so on).          |
+| `domain/`         | Domain rules that do not depend on Express or Sequelize (registration, gamification).               |
+| `infrastructure/` | Adapters: `queue/` (BullMQ and Redis), `storage/` (S3/MinIO), `email/` (Resend), `security/`. |
+| `interface/http/` | Cross cutting middlewares: `auth-jwt`, `require-role`, `request-id`, `require-https`.         |
+| `models/`         | Sequelize models and their associations (`models/index.ts`).                                      |
+| `config/`         | `database.ts` (Sequelize bootstrap) and `jwt.ts` (token secret).                                 |
+| `docs/`           | The OpenAPI 3.0.3 document served through Swagger UI.                                               |
+| `workers/`        | Standalone process entrypoints, currently `email-worker.ts`.                                      |
 
-```json
-{
-  "_id": "objectId",
-  "title": "string",
-  "description": "string",
-  "documentId": "objectId"
-}
-```
+### Processes
 
-## Feature Implementation
+The backend runs as two independent Node processes built from the same codebase:
 
-### Feature F01 - User Registration
+| Process | Command                                | Role                                                           |
+| ------- | -------------------------------------- | -------------------------------------------------------------- |
+| Web     | `node build/index.js`                | Serves the REST API and Swagger UI.                            |
+| Worker  | `node build/workers/email-worker.js` | Consumes the BullMQ email queue and delivers through Resend.   |
 
-* **Description:** The doctor or administrator registers on the system with basic information such as name, email, and password.
-* **Process:** The user fills out a registration form. The backend validates the information, and if everything is correct, a new user is created in the database.
+### Domain model
 
-### Feature F05 - User Login
+Sequelize models live in `src/models` and are wired together in `src/models/index.ts`. The main aggregates:
 
-* **Description:** Allows doctors and administrators to log in using their email and password.
-* **Process:** The user submits their credentials, which are validated by the system. If valid, a JWT token is generated and sent to the frontend.
+| Aggregate    | Models                                                                                        |
+| ------------ | --------------------------------------------------------------------------------------------- |
+| Identity     | `User`, `RegistrationProfile`, `RegistrationReview`, `EmailVerification`, `PasswordReset` |
+| Catalog      | `Course`, `Section`, `Activity`, `Tag`, `CourseTag`, `Institution`                  |
+| Learning     | `Enrollment`, `CourseProgress`, `SectionProgress`, `ActivityProgress`                 |
+| Gamification | `PointsLedger`, `StudentStats`, `Badge`, `StudentBadge`                               |
+| Recognition  | `Certificate`, `CourseReview`                                                             |
+| Media        | `MediaAsset`                                                                                |
 
-### Feature F12 - Subscription Management
+Key associations:
 
-* **Description:** The doctor can access their financial area to manage their subscription.
-* **Process:** The backend retrieves the doctor's financial information and displays the details on the frontend.
+- A `Course` belongs to a `User` (the owner/creator) and has many `Section` records; each `Section` has many
+  `Activity` records.
+- `Course` and `Tag` form a many to many relation through `CourseTag`.
+- Progress is a three level chain: `CourseProgress` has many `SectionProgress`, which has many
+  `ActivityProgress`.
+- A `User` has one `RegistrationProfile` and many `RegistrationReview` records, both as subject and as reviewer.
+- A `User` has many `MediaAsset` records and points to one of them as the avatar (`avatarMediaId`).
 
-# Revision History
+Identifiers are UUIDs in PostgreSQL. Column level detail is in [Database Schema](database-schema.md).
 
-| Date       | Version | Changes                           | Authors |
-| ---------- | ------- | --------------------------------- | ------- |
-| 02/04/2024 | 0.1     | Document creation                 |         |
-| 06/04/2024 | 0.2     | Topics 1.1, 1.2, 1.3, and 3       |         |
-| 16/04/2024 | 0.3     | Documentation on Git Pages        |         |
-| 09/09/2024 | 0.4     | Updated technologies and app type |         |
-| 09/09/2024 | 0.5     | Technology adjustments            |         |
+Schema changes are applied by `sequelize.sync()` in `src/config/database.ts`. Outside production the sync runs with
+`alter: true`; in production it never alters, so structural changes must be planned deliberately.
+
+## Authentication and Authorization
+
+- Login endpoints return a signed JWT. Clients send it as `Authorization: Bearer <token>`.
+- `requireAuth` (`src/interface/http/middlewares/auth-jwt.ts`) verifies the token with `ACCESS_TOKEN_SECRET` and
+  puts `{ userId, role }` into `res.locals.auth`.
+- Roles are `ADMIN`, `STUDENT` and `USER` (the last one covers content creators). Route level enforcement uses
+  `requireRole(...roles)`, which answers `403 FORBIDDEN` when the role is not allowed.
+- Errors are returned as machine readable codes, for example `{ "code": "UNAUTHORIZED" }`.
+- Creator accounts are not active on sign up: they create a registration that an administrator approves or rejects
+  under `/admin/registrations`.
+- Passwords are hashed with bcryptjs. Password reset is a three step flow (request, verify, reset) backed by the
+  `PasswordReset` model.
+- Media streaming (`/media/:id/stream`) accepts the token as a query parameter so that `<img>` and `<video>`
+  tags can consume protected assets.
+
+## Cross cutting concerns
+
+| Concern       | Implementation                                                                                                                                 |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| CORS          | `FRONTEND_ORIGIN` holds a comma separated allowlist. Outside production every origin is allowed to speed up local work.                       |
+| HTTPS         | `requireHttpsInProduction` rejects plain HTTP once `NODE_ENV=production`. `trust proxy` is on because the API sits behind a reverse proxy. |
+| Request IDs   | `requestIdMiddleware` tags every request so logs can be correlated.                                                                          |
+| Rate limiting | `express-rate-limit` on sensitive endpoints.                                                                                                 |
+| Payload size  | `express.urlencoded` is capped; uploads go through `multer` straight to object storage.                                                    |
+
+## Data Flow
+
+### Media upload
+
+1. The client authenticates and calls `POST /media/images` (or the multipart video init/part/complete flow).
+2. The API streams the file to MinIO through the S3 client and records a `MediaAsset` row with the owner.
+3. Reads go through `GET /media/images/:id`, `GET /media/videos/:id` or `GET /media/:id/stream`, which
+   resolves the object from storage.
+
+### Transactional email
+
+1. A use case (email verification, password reset, registration decision) enqueues a job on the BullMQ queue backed by
+   Redis.
+2. The email worker process consumes the queue and delivers through Resend using `EMAIL_API_KEY` and `EMAIL_FROM`.
+3. Failures stay in the queue and are retried by BullMQ, so a provider outage does not break the request path.
+
+### Course consumption
+
+1. The student browses `/catalog/courses` and enrolls through `/student/enrollments`.
+2. Activity answers are posted to `/student/activities/:activityId/answer`, which updates the progress chain and
+   writes to the points ledger.
+3. On completion the platform issues a `Certificate`, downloadable as a PDF and verifiable through
+   `/certificates/verify/:code`.
+
+## Revision History
+
+| Date       | Version | Changes                                                                                    | Authors       |
+| ---------- | ------- | ------------------------------------------------------------------------------------------ | ------------- |
+| 02/04/2024 | 0.1     | Document creation                                                                          |               |
+| 06/04/2024 | 0.2     | Topics 1.1, 1.2, 1.3, and 3                                                                |               |
+| 16/04/2024 | 0.3     | Documentation on Git Pages                                                                 |               |
+| 09/09/2024 | 0.4     | Updated technologies and app type                                                          |               |
+| 09/09/2024 | 0.5     | Technology adjustments                                                                     |               |
+| 13/08/2026 | 1.0     | Full rewrite against the implemented system (PostgreSQL, Express 5, Vite web, Expo mobile) | Lucas Antunes |
 
 [← Back to Main Page](../../index.md)

--- a/docs/development/technical/architecture.md
+++ b/docs/development/technical/architecture.md
@@ -40,7 +40,7 @@ Public environments:
 | ----------------------- | ------------------------------------------------------------- |
 | **Runtime**             | Node.js 20 (`engines.node >= 20`)                           |
 | **HTTP framework**      | Express 5                                                     |
-| **Language**            | TypeScript 5.9 across API, web and mobile                     |
+| **Language**            | TypeScript, pinned per project: `5.9.3` in the API, `^5.9.3` in the web app, `~6.0.3` in the mobile app |
 | **Database**            | PostgreSQL 16 accessed through Sequelize 6                    |
 | **Cache and queue**     | Redis 7.2 with BullMQ 5 (email queue)                         |
 | **Object storage**      | MinIO, S3 compatible, driven by the AWS SDK v3 client         |
@@ -54,6 +54,10 @@ Public environments:
 
     The web application is plain TypeScript with a small hand written router (`src/app/router.ts`). There is no Vue,
     React or Angular in `educado-web`. React Native is used only in the mobile app.
+
+    The three projects are not on the same TypeScript major: the mobile app moved to 6.x with Expo SDK 56, while the
+    API and the web app are still on 5.9. Do not assume a type level feature available in one is available in the
+    others.
 
 ## Component Architecture
 
@@ -138,8 +142,20 @@ Schema changes are applied by `sequelize.sync()` in `src/config/database.ts`. Ou
 - Login endpoints return a signed JWT. Clients send it as `Authorization: Bearer <token>`.
 - `requireAuth` (`src/interface/http/middlewares/auth-jwt.ts`) verifies the token with `ACCESS_TOKEN_SECRET` and
   puts `{ userId, role }` into `res.locals.auth`.
-- Roles are `ADMIN`, `STUDENT` and `USER` (the last one covers content creators). Route level enforcement uses
-  `requireRole(...roles)`, which answers `403 FORBIDDEN` when the role is not allowed.
+- Roles are `ADMIN`, `STUDENT` and `USER` (the last one covers content creators).
+- Authorization is **not** uniform across the API. There are two mechanisms in use:
+    - `requireRole(...roles)` (`src/interface/http/middlewares/require-role.ts`), a middleware that answers
+      `403 FORBIDDEN` when the role is not allowed. It is applied in exactly seven places, all of them
+      `router.use(requireRole('STUDENT'))` at the top of a `src/routes/student/*` router: `activities`,
+      `certificates`, `enrollments`, `gamification`, `profile`, `progress` and `reviews`. In other words it guards
+      the `/student` surface as a whole and nothing else.
+    - `ensureAdminRole(role)` (`src/application/registration/registration-service.ts:582`), a plain function called
+      **inside each handler**, after the role is read from `res.locals.auth`. This is how administrative access is
+      enforced: eight call sites in `src/routes/admin/registrations.ts` and five in
+      `src/routes/institutions/institutions-crud.ts`.
+- The practical consequence: adding a handler to an admin router grants no protection by itself. The check is
+  per handler, so a new route without an explicit `ensureAdminRole(role)` call is reachable by any authenticated
+  user. Reading the router preamble is not enough to know whether a route is guarded.
 - Errors are returned as machine readable codes, for example `{ "code": "UNAUTHORIZED" }`.
 - Creator accounts are not active on sign up: they create a registration that an administrator approves or rejects
   under `/admin/registrations`.

--- a/docs/development/technical/deployment.md
+++ b/docs/development/technical/deployment.md
@@ -1,0 +1,162 @@
+# Deployment & Infrastructure
+
+[← Back to Main Page](../../index.md)
+
+This page documents how Educado actually runs in the deployed environment: the topology, the build strategies, the
+domains, and the complete table of environment variables.
+
+For the local development setup see the [Back End Getting Started](../../handbook/back-end/getting-started.md) and the
+[Web Getting Started](../../handbook/web/getting-started.md) guides.
+
+## Topology
+
+Everything runs on a single VPS managed by **Coolify 4.3.1**, a self hosted PaaS. Coolify provisions the containers,
+manages the environment variables and configures **Traefik** as the reverse proxy, which terminates TLS and routes the
+public hostnames to the right container.
+
+```text
+                Internet
+                    |
+                 (443/tcp)
+                    |
+              +-----v------+
+              |  Traefik   |  TLS termination, routing (managed by Coolify)
+              +--+------+--+
+                 |      |
+   educado.tominho.com  api-educado.tominho.com
+                 |      |
+       +---------v+    +v-----------------+
+       | web      |    | api (Express)    |
+       | nginx    |    | node build/index.js
+       +----------+    +--+-------+-------+
+                          |       |
+                          |       +-------------------+
+              +-----------v--+  +-v---------+  +------v------+
+              | PostgreSQL 16|  | Redis 7.2 |  | MinIO (S3)  |
+              +--------------+  +-----+-----+  +-------------+
+                                      |
+                              +-------v----------+
+                              | email worker     |
+                              | node build/workers/email-worker.js
+                              +------------------+
+```
+
+All application containers share the internal Coolify Docker network, so the API reaches PostgreSQL, Redis and MinIO by
+service name. Only Traefik publishes ports to the internet: the databases and the object storage are never exposed
+directly.
+
+## Domains
+
+| Component  | Hostname                                                                        |
+| ---------- | ------------------------------------------------------------------------------- |
+| Web app    | [https://educado.tominho.com](https://educado.tominho.com)                      |
+| API        | [https://api-educado.tominho.com](https://api-educado.tominho.com)              |
+| Swagger UI | [https://api-educado.tominho.com/docs/](https://api-educado.tominho.com/docs/)  |
+
+## Deployed components
+
+| Component     | Build strategy | Start command                          | Notes                                                          |
+| ------------- | -------------- | -------------------------------------- | -------------------------------------------------------------- |
+| API           | Nixpacks       | `node build/index.js`                | Express server plus Swagger UI.                                |
+| Email worker  | Nixpacks       | `node build/workers/email-worker.js` | Same repository and build, separate process. No public domain.  |
+| Web           | Dockerfile     | `nginx -g "daemon off;"`             | Multi stage build: Node 20 builds, nginx serves `/dist`.     |
+| PostgreSQL 16 | Coolify resource | managed                              | Persistent volume.                                             |
+| Redis 7.2     | Coolify resource | managed                              | Password protected.                                            |
+| MinIO         | Docker Compose | managed                                | See the caveat below.                                          |
+
+!!! warning "MinIO is not in the Coolify 4.3.1 catalog"
+
+    MinIO was removed from the Coolify service catalog in 4.3.1, so it cannot be added as a one click resource. It is
+    deployed as a **Docker Compose** resource inside Coolify instead. When rebuilding the environment from scratch,
+    do not look for it in the service list: create a Compose resource with the MinIO image, attach a persistent volume
+    and create the media bucket before pointing the API at it.
+
+### Web build argument
+
+The web application is a static bundle, so the API URL is baked in **at build time**, not at runtime. The Dockerfile
+declares:
+
+```dockerfile
+ARG VITE_API_URL
+ENV VITE_API_URL=${VITE_API_URL}
+RUN npm run build
+```
+
+`VITE_API_URL` must be set as a **build argument** in Coolify (value: `https://api-educado.tominho.com`). Setting
+it only as a runtime environment variable has no effect: the bundle will fall back to `http://localhost:5001` and the
+deployed site will fail to reach the API. Changing the API URL requires a rebuild, not a restart.
+
+nginx serves the bundle with an SPA fallback (`try_files $uri $uri/ /index.html`) and long lived cache headers for
+hashed assets.
+
+## Environment variables
+
+### API and email worker
+
+Both processes are built from the same repository and take the same variables.
+
+| Variable                | Required            | Description                                                                                     |
+| ----------------------- | ------------------- | ------------------------------------------------------------------------------------------------ |
+| `NODE_ENV`            | Yes                 | Must be exactly `production` in the deployed environment. See the trap below.                  |
+| `PORT`                | Yes                 | Port the Express server listens on. Defaults to `5000` if unset.                               |
+| `POSTGRES_URI`        | Yes (production)    | PostgreSQL connection string. Read **only** when `NODE_ENV === 'production'`.                 |
+| `POSTGRES_URI_DEV`    | Yes (non production) | Connection string used whenever `NODE_ENV` is not `production`.                              |
+| `ACCESS_TOKEN_SECRET` | Yes                 | Secret used to sign and verify JWTs. Generate with `openssl rand -base64 48`.                  |
+| `FRONTEND_ORIGIN`     | Yes (production)    | Comma separated CORS allowlist, for example `https://educado.tominho.com`.                     |
+| `S3_ENDPOINT`         | Yes                 | MinIO/S3 endpoint URL.                                                                          |
+| `S3_REGION`           | Yes                 | Region string, for example `us-east-1`.                                                        |
+| `S3_ACCESS_KEY`       | Yes                 | Object storage access key.                                                                      |
+| `S3_SECRET_KEY`       | Yes                 | Object storage secret key.                                                                      |
+| `S3_BUCKET`           | Yes                 | Bucket holding media assets, for example `educado-media`.                                      |
+| `EMAIL_API_KEY`       | Yes                 | Resend API key. Without it the worker cannot deliver.                                           |
+| `EMAIL_FROM`          | Yes                 | Sender address used on transactional email.                                                     |
+| `REDIS_HOST`          | Yes                 | Redis hostname. Defaults to `127.0.0.1` if unset, which is wrong in a container.               |
+| `REDIS_PORT`          | Yes                 | Redis port. Defaults to `6379`.                                                                |
+| `REDIS_PASSWORD`      | Yes, when Redis has a password | Read in `src/infrastructure/queue/redis.ts`. Omitting it makes every queue operation fail with `NOAUTH`. |
+
+### Web
+
+| Variable         | Scope           | Description                                                                        |
+| ---------------- | --------------- | ---------------------------------------------------------------------------------- |
+| `VITE_API_URL` | **Build time** | Base URL of the API. Must be a Docker build argument, not a runtime variable.       |
+
+## Operational traps
+
+!!! danger "`NODE_ENV` must be exactly `production`"
+
+    `src/config/database.ts` selects the connection string like this:
+
+    ```ts
+    const isProd = () => process.env.NODE_ENV === 'production'
+    const postgresUri = isProd() ? process.env.POSTGRES_URI : process.env.POSTGRES_URI_DEV
+    ```
+
+    Any other value, including `staging`, makes the API look for `POSTGRES_URI_DEV`. In a deployed environment that
+    variable does not exist, the connection fails, and the process exits with `process.exit(1)`, which the supervisor
+    restarts, producing a crash loop. If the API is restarting endlessly right after a deploy, check `NODE_ENV`
+    first.
+
+    The same flag also drives HTTPS enforcement, CORS strictness and whether `sequelize.sync()` is allowed to alter
+    tables, so the value is not cosmetic.
+
+!!! warning "Redis with a password"
+
+    `REDIS_PASSWORD` has no default. When the Redis resource requires authentication and the variable is missing,
+    BullMQ connects but every command is rejected, so email jobs are enqueued and never delivered.
+
+!!! note "Schema changes in production"
+
+    In production `sequelize.sync()` runs without `alter`, so new columns are not created automatically. Structural
+    changes must be applied deliberately before the deploy that depends on them.
+
+## Deploy checklist
+
+1. Confirm `NODE_ENV=production` on both the API and the worker.
+2. Confirm `POSTGRES_URI`, `REDIS_HOST`, `REDIS_PORT` and `REDIS_PASSWORD` point at the Coolify resources.
+3. Confirm the S3 variables point at MinIO and that the bucket exists.
+4. Confirm `FRONTEND_ORIGIN` contains the deployed web origin, otherwise the browser blocks every request.
+5. For the web app, confirm `VITE_API_URL` is set as a **build argument** and trigger a rebuild after changing it.
+6. After deploying, check [https://api-educado.tominho.com/docs/](https://api-educado.tominho.com/docs/) and load the
+   web app once to validate the API URL that was compiled into the bundle.
+
+[← Back to Main Page](../../index.md)

--- a/docs/development/technical/deployment.md
+++ b/docs/development/technical/deployment.md
@@ -3,19 +3,27 @@
 [← Back to Main Page](../../index.md)
 
 This page documents how Educado actually runs in the deployed environment: the topology, the build strategies, the
-domains, and the complete table of environment variables.
+domains, and the environment variables read by the code. The variable table below is kept in sync with the
+`process.env` reads in `educado-api/src`; when a new one is introduced, add it here in the same commit.
 
 For the local development setup see the [Back End Getting Started](../../handbook/back-end/getting-started.md) and the
 [Web Getting Started](../../handbook/web/getting-started.md) guides.
 
 ## Topology
 
-Everything runs on a single VPS managed by **Coolify 4.3.1**, a self hosted PaaS. Coolify provisions the containers,
-manages the environment variables and configures **Traefik** as the reverse proxy, which terminates TLS and routes the
-public hostnames to the right container.
+Everything runs on a single VPS managed by **Coolify 4.3.1** (version observed in the panel on 2026-08-13), a self
+hosted PaaS. Coolify provisions the containers, manages the environment variables and configures **Traefik** as the
+reverse proxy, which terminates TLS and routes the public hostnames to the right container. Public traffic does not
+reach Traefik directly: a **Cloudflare Tunnel** sits in front of the VPS, so Cloudflare is the first hop for every
+request.
 
 ```text
                 Internet
+                    |
+              +-----v-------------+
+              | Cloudflare        |  DNS, TLS at the edge, Tunnel to the VPS
+              | (Tunnel, Free)    |  request body limit: 100 MB
+              +-----+-------------+
                     |
                  (443/tcp)
                     |
@@ -45,6 +53,19 @@ All application containers share the internal Coolify Docker network, so the API
 service name. Only Traefik publishes ports to the internet: the databases and the object storage are never exposed
 directly.
 
+!!! warning "Cloudflare caps the request body at 100 MB"
+
+    On the Cloudflare Free plan the maximum request body size is **100 MB**, and that ceiling applies to every
+    request that crosses the tunnel, including media uploads. The API code accounts for it explicitly: the comment
+    above the legacy direct upload route in `src/routes/media/upload-video.ts` (lines 30-31) marks the endpoint as
+    "subject to the reverse-proxy body limit (Cloudflare Free = 100 MB)".
+
+    This is why video upload uses the **chunked flow** (`/media/videos/init`,
+    `/media/videos/:id/parts/:partNumber`, `/media/videos/:id/complete`): each part is bounded by the client side
+    chunk size of 50 MB, comfortably below the ceiling. The legacy `POST /media/videos` route uploads the whole file
+    in one request, so anything above 100 MB is rejected at the edge, before the API ever sees it. A failed large
+    upload with no trace in the API logs is the signature of this limit.
+
 ## Domains
 
 | Component  | Hostname                                                                        |
@@ -66,7 +87,8 @@ directly.
 
 !!! warning "MinIO is not in the Coolify 4.3.1 catalog"
 
-    MinIO was removed from the Coolify service catalog in 4.3.1, so it cannot be added as a one click resource. It is
+    MinIO was removed from the Coolify service catalog in 4.3.1, so it cannot be added as a one click resource
+    (observed in the Coolify panel on 2026-08-13; re-check when the instance is upgraded). It is
     deployed as a **Docker Compose** resource inside Coolify instead. When rebuilding the environment from scratch,
     do not look for it in the service list: create a Compose resource with the MinIO image, attach a persistent volume
     and create the media bucket before pointing the API at it.
@@ -98,18 +120,24 @@ Both processes are built from the same repository and take the same variables.
 | Variable                | Required            | Description                                                                                     |
 | ----------------------- | ------------------- | ------------------------------------------------------------------------------------------------ |
 | `NODE_ENV`            | Yes                 | Must be exactly `production` in the deployed environment. See the trap below.                  |
-| `PORT`                | Yes                 | Port the Express server listens on. Defaults to `5000` if unset.                               |
+| `PORT`                | No                  | Port the Express server listens on. Defaults to `5000` when unset (`src/index.ts:41`).       |
 | `POSTGRES_URI`        | Yes (production)    | PostgreSQL connection string. Read **only** when `NODE_ENV === 'production'`.                 |
 | `POSTGRES_URI_DEV`    | Yes (non production) | Connection string used whenever `NODE_ENV` is not `production`.                              |
 | `ACCESS_TOKEN_SECRET` | Yes                 | Secret used to sign and verify JWTs. Generate with `openssl rand -base64 48`.                  |
+| `JWT_SECRET`          | No (alias)          | Accepted alias of `ACCESS_TOKEN_SECRET`, read in `src/config/jwt.ts:7` as `process.env.ACCESS_TOKEN_SECRET ?? process.env.JWT_SECRET`. `ACCESS_TOKEN_SECRET` wins when both are set. Set one, not both. |
 | `FRONTEND_ORIGIN`     | Yes (production)    | Comma separated CORS allowlist, for example `https://educado.tominho.com`.                     |
-| `S3_ENDPOINT`         | Yes                 | MinIO/S3 endpoint URL.                                                                          |
-| `S3_REGION`           | Yes                 | Region string, for example `us-east-1`.                                                        |
-| `S3_ACCESS_KEY`       | Yes                 | Object storage access key.                                                                      |
-| `S3_SECRET_KEY`       | Yes                 | Object storage secret key.                                                                      |
+| `S3_ENDPOINTS`        | No, but it overrides `S3_ENDPOINT` | Comma separated list of S3/MinIO endpoints, tried in order. **Takes precedence over `S3_ENDPOINT`.** See the trap below. |
+| `S3_ENDPOINT`         | Yes, unless `S3_ENDPOINTS` is set | Single MinIO/S3 endpoint URL. Ignored whenever `S3_ENDPOINTS` is set and non empty. Defaults to `http://localhost:9000`. |
+| `S3_REGION`           | Yes                 | Region string, for example `us-east-1`. Defaults to `us-east-1`.                              |
+| `S3_ACCESS_KEY`       | Yes                 | Object storage access key. Defaults to `minioadmin`.                                           |
+| `S3_SECRET_KEY`       | Yes                 | Object storage secret key. Defaults to `minioadmin`.                                           |
 | `S3_BUCKET`           | Yes                 | Bucket holding media assets, for example `educado-media`.                                      |
+| `S3_MAX_ATTEMPTS`     | No                  | How many times each endpoint is retried on a transient network error (`EAI_AGAIN`, `ENOTFOUND`, `ECONNRESET`, `ETIMEDOUT`). Defaults to `3`. Values below 1 or unparseable fall back to the default. |
+| `S3_RETRY_DELAY_MS`   | No                  | Delay in milliseconds between those retries. Defaults to `150`. Same fallback rule as above.  |
 | `EMAIL_API_KEY`       | Yes                 | Resend API key. Without it the worker cannot deliver.                                           |
 | `EMAIL_FROM`          | Yes                 | Sender address used on transactional email.                                                     |
+| `SYSTEM_REVIEWER_EMAIL` | No                | Identity recorded as the reviewer when a creator registration is auto approved by verified email domain (`AUTO_EMAIL_DOMAIN_VERIFIED`). Read in `src/application/verification/email-verification-service.ts:22`. Defaults to `system@educado.local`, an address that does not resolve, so set a real mailbox if the audit trail matters. |
+| `CERTIFICATE_VERIFICATION_URL` | Yes (production) | Base URL printed on every issued certificate PDF. See the trap below: the built in default points outside the project. |
 | `REDIS_HOST`          | Yes                 | Redis hostname. Defaults to `127.0.0.1` if unset, which is wrong in a container.               |
 | `REDIS_PORT`          | Yes                 | Redis port. Defaults to `6379`.                                                                |
 | `REDIS_PASSWORD`      | Yes, when Redis has a password | Read in `src/infrastructure/queue/redis.ts`. Omitting it makes every queue operation fail with `NOAUTH`. |
@@ -139,6 +167,47 @@ Both processes are built from the same repository and take the same variables.
     The same flag also drives HTTPS enforcement, CORS strictness and whether `sequelize.sync()` is allowed to alter
     tables, so the value is not cosmetic.
 
+!!! danger "`S3_ENDPOINTS` silently overrides `S3_ENDPOINT`"
+
+    The two variables look interchangeable and are not. `src/infrastructure/storage/s3/s3-client.ts:50` resolves the
+    endpoint list like this:
+
+    ```ts
+    const rawEndpoints =
+      process.env.S3_ENDPOINTS || process.env.S3_ENDPOINT || DEFAULT_S3_ENDPOINT
+    ```
+
+    `S3_ENDPOINTS` (**plural**) is read first. If it is set to anything non empty, `S3_ENDPOINT` (singular) is never
+    read at all. Editing the singular variable to repoint storage while a stale plural one is still present in the
+    Coolify environment changes nothing, and the failure looks like a caching or DNS problem rather than a
+    configuration one. When storage points at the wrong place, check `S3_ENDPOINTS` **before** `S3_ENDPOINT`.
+
+    The plural form takes a comma separated list. Entries are trimmed, empties are dropped and duplicates are
+    removed, then each endpoint is tried in order, which is what makes it useful: an internal Docker hostname first,
+    a public URL as fallback. Falling back to `http://localhost:9000` in a container is the symptom of both being
+    unset.
+
+!!! danger "`CERTIFICATE_VERIFICATION_URL` defaults to a domain the project does not own"
+
+    `src/application/certificates/certificate-pdf-service.ts:8` falls back to a hardcoded value:
+
+    ```ts
+    const VERIFICATION_BASE_URL =
+      process.env.CERTIFICATE_VERIFICATION_URL ||
+      'https://educado.com/certificates/verify'
+    ```
+
+    `educado.com` is **not** a domain of this project. If the variable is not configured, every certificate issued in
+    production is stamped with a verification link pointing at third party infrastructure, and nothing fails loudly:
+    the PDF is generated, the student receives it, and the link only breaks when someone tries to verify it. Worse,
+    already issued PDFs cannot be corrected after the fact.
+
+    Set it explicitly on the API and the worker, and check it before the first certificate is issued in any new
+    environment. The only verification surface that exists today is the public API route
+    `GET /certificates/verify/:code`, so `https://api-educado.tominho.com/certificates/verify` is a value that
+    actually resolves. There is no verification page in `educado-web` yet; once one exists, point the variable at it
+    instead.
+
 !!! warning "Redis with a password"
 
     `REDIS_PASSWORD` has no default. When the Redis resource requires authentication and the variable is missing,
@@ -153,10 +222,12 @@ Both processes are built from the same repository and take the same variables.
 
 1. Confirm `NODE_ENV=production` on both the API and the worker.
 2. Confirm `POSTGRES_URI`, `REDIS_HOST`, `REDIS_PORT` and `REDIS_PASSWORD` point at the Coolify resources.
-3. Confirm the S3 variables point at MinIO and that the bucket exists.
-4. Confirm `FRONTEND_ORIGIN` contains the deployed web origin, otherwise the browser blocks every request.
-5. For the web app, confirm `VITE_API_URL` is set as a **build argument** and trigger a rebuild after changing it.
-6. After deploying, check [https://api-educado.tominho.com/docs/](https://api-educado.tominho.com/docs/) and load the
+3. Confirm the S3 variables point at MinIO and that the bucket exists. Check `S3_ENDPOINTS` first: when it is set it
+   overrides `S3_ENDPOINT` entirely.
+4. Confirm `CERTIFICATE_VERIFICATION_URL` is set, so certificates are not stamped with the `educado.com` default.
+5. Confirm `FRONTEND_ORIGIN` contains the deployed web origin, otherwise the browser blocks every request.
+6. For the web app, confirm `VITE_API_URL` is set as a **build argument** and trigger a rebuild after changing it.
+7. After deploying, check [https://api-educado.tominho.com/docs/](https://api-educado.tominho.com/docs/) and load the
    web app once to validate the API URL that was compiled into the bundle.
 
 [← Back to Main Page](../../index.md)

--- a/docs/development/tools.md
+++ b/docs/development/tools.md
@@ -38,11 +38,18 @@ The tools below are the ones actually used by the Educado project. For the runti
 | Tool          | Description                                                                                       | Link                                             |
 | ------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
 | **Vite**      | Build tool and dev server for the web application. The web app is plain TypeScript, no framework. | [Vite](https://vite.dev/)                        |
-| **axios**     | HTTP client used by the web application.                                                          | [axios](https://axios-http.com/)                 |
+| **`fetch` wrapper** | The web application has no HTTP client library. All calls go through a small in house wrapper over the native `fetch`, in `src/shared/api/http.ts`, which prefixes the base URL, attaches the bearer token, parses JSON and throws a typed `ApiError`. | [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) |
+| **flatpickr** | Date picker used in the web auth flow, in `src/features/auth/components/AuthProfileStep.ts` and `src/features/auth/pages/EditProfilePage.ts`, with the month select plugin and the pt-BR locale. | [flatpickr](https://flatpickr.js.org/)   |
 | **nginx**     | Serves the built web assets in production and handles the SPA fallback.                           | [nginx](https://nginx.org/)                      |
 | **Expo (SDK 56)** | Toolchain for the React Native mobile app, Android first.                                     | [Expo](https://expo.dev/)                        |
 | **React Native** | UI framework for the mobile app.                                                               | [React Native](https://reactnative.dev/)         |
 | **EAS Build** | Builds the mobile binaries (.apk / .aab) for distribution.                                        | [EAS Build](https://docs.expo.dev/build/introduction/) |
+
+!!! note "axios is declared but not used"
+
+    `axios` still appears in the `dependencies` of `educado-web/package.json`, but there is not a single import of
+    it in `src/`. It is a leftover and should not be used for new code: the `fetch` wrapper above already handles
+    the base URL, authentication and error shape consistently.
 
 ## Infrastructure and delivery
 

--- a/docs/development/tools.md
+++ b/docs/development/tools.md
@@ -3,20 +3,62 @@
 
 [← Back to Main Page](../index.md)
 
-## Tools Used
+The tools below are the ones actually used by the Educado project. For the runtime topology see
+[Deployment & Infrastructure](technical/deployment.md), and for the system design see
+[System Architecture](technical/architecture.md).
 
-| Tool                 | Description                                                                                                                                                                                       | Link                                         |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| **GitHub**     | Source code hosting and version control platform. Used for code versioning, developer collaboration, and CI/CD integration.                                                                       | [GitHub](https://github.com/)                   |
-| **Express.js** | Node.js framework used to build the system's RESTful APIs, simplifying routing and middleware handling.                                                                                           | [Express.js](https://expressjs.com/)            |
-| **Vue.js**     | JavaScript framework for building user interfaces and Single Page Applications (SPA). Used for front-end development of the system.                                                               | [Vue.js](https://vuejs.org/)                    |
-| **Postman**    | Tool used to test APIs and endpoints, ensuring that requests and responses behave as expected.                                                                                                    | [Postman](https://www.postman.com/)             |
-| **Docker**     | Containerization platform that simplifies the creation, development, and execution of applications in isolated environments, ensuring consistency across development and production environments. | [Docker](https://www.docker.com/)               |
-| **Swagger**    | Tool for documenting and testing RESTful APIs, allowing developers and stakeholders to easily visualize and interact with API endpoints.                                                          | [Swagger](https://swagger.io/)                  |
-| **Nginx**      | Web server and reverse proxy used for load distribution, traffic balancing, and static file hosting for the front-end of the system.                                                              | [Nginx](https://www.nginx.com/)                 |
-| **Jenkins**    | Continuous integration tool that automates the build, test, and deployment process of the system.                                                                                                 | [Jenkins](https://www.jenkins.io/)              |
-| **Redis**      | In-memory database used for caching and performance optimization, ensuring fast responses and scalability.                                                                                        | [Redis](https://redis.io/)                      |
-| **New Relic**  | Application performance monitoring tool that provides detailed metrics about system performance, identifying bottlenecks and areas for improvement.                                               | [New Relic](https://newrelic.com/)              |
+## Development and collaboration
+
+| Tool                     | Description                                                                                  | Link                                                             |
+| ------------------------ | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| **GitHub**               | Source hosting, code review and issue tracking for every Educado repository.                 | [GitHub](https://github.com/)                                    |
+| **GitHub Actions**       | CI for the repositories, including the documentation build (`mkdocs build --strict`).      | [GitHub Actions](https://github.com/features/actions)            |
+| **MkDocs Material**      | Static site generator behind this documentation.                                             | [MkDocs Material](https://squidfunk.github.io/mkdocs-material/)  |
+| **uv**                   | Python dependency manager used to run and build the documentation site.                      | [uv](https://docs.astral.sh/uv/)                                 |
+
+## Back end
+
+| Tool                | Description                                                                                        | Link                                                       |
+| ------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **Node.js 20**      | Runtime for the API and the email worker.                                                          | [Node.js](https://nodejs.org/)                             |
+| **Express 5**       | HTTP framework used to build the REST API.                                                         | [Express](https://expressjs.com/)                          |
+| **TypeScript**      | Language used across API, web and mobile.                                                          | [TypeScript](https://www.typescriptlang.org/)              |
+| **Sequelize**       | ORM mapping the PostgreSQL schema to the models in `src/models`.                                 | [Sequelize](https://sequelize.org/)                        |
+| **PostgreSQL 16**   | Relational database, single source of truth for platform data.                                     | [PostgreSQL](https://www.postgresql.org/)                  |
+| **Redis 7.2**       | Backing store for the BullMQ job queue.                                                            | [Redis](https://redis.io/)                                 |
+| **BullMQ**          | Job queue used for asynchronous email delivery.                                                    | [BullMQ](https://docs.bullmq.io/)                          |
+| **MinIO**           | S3 compatible object storage for images and videos.                                                | [MinIO](https://min.io/)                                   |
+| **Resend**          | Transactional email provider (verification, password reset, registration decisions).               | [Resend](https://resend.com/)                              |
+| **Swagger UI**      | API documentation served by the API itself at `/docs/`.                                          | [Swagger](https://swagger.io/)                             |
+| **Jest**            | Unit and integration test runner for the API, with `supertest` for HTTP level tests.             | [Jest](https://jestjs.io/)                                 |
+| **ESLint + Prettier** | Linting and formatting for the TypeScript codebases.                                             | [ESLint](https://eslint.org/)                              |
+
+## Front end
+
+| Tool          | Description                                                                                       | Link                                             |
+| ------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| **Vite**      | Build tool and dev server for the web application. The web app is plain TypeScript, no framework. | [Vite](https://vite.dev/)                        |
+| **axios**     | HTTP client used by the web application.                                                          | [axios](https://axios-http.com/)                 |
+| **nginx**     | Serves the built web assets in production and handles the SPA fallback.                           | [nginx](https://nginx.org/)                      |
+| **Expo (SDK 56)** | Toolchain for the React Native mobile app, Android first.                                     | [Expo](https://expo.dev/)                        |
+| **React Native** | UI framework for the mobile app.                                                               | [React Native](https://reactnative.dev/)         |
+| **EAS Build** | Builds the mobile binaries (.apk / .aab) for distribution.                                        | [EAS Build](https://docs.expo.dev/build/introduction/) |
+
+## Infrastructure and delivery
+
+| Tool         | Description                                                                                                  | Link                                       |
+| ------------ | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
+| **Coolify**  | Self hosted PaaS (version 4.3.1) that deploys and supervises the API, the email worker and the web app.       | [Coolify](https://coolify.io/)             |
+| **Nixpacks** | Build strategy used by Coolify for the Node processes (API and email worker).                                | [Nixpacks](https://nixpacks.com/)          |
+| **Docker**   | Containerisation. The web app ships a multi stage Dockerfile; local infrastructure runs via Docker Compose.   | [Docker](https://www.docker.com/)          |
+| **Traefik**  | Reverse proxy managed by Coolify, terminating TLS for the public domains.                                    | [Traefik](https://traefik.io/)             |
+
+## Testing and inspection
+
+| Tool         | Description                                                       | Link                                        |
+| ------------ | ----------------------------------------------------------------- | ------------------------------------------- |
+| **Postman**  | Manual API exploration alongside Swagger UI.                      | [Postman](https://www.postman.com/)         |
+| **Swagger UI** | Interactive contract for the API, canonical for request shapes. | [Swagger](https://swagger.io/)              |
 
 ---
 

--- a/docs/handbook/back-end/getting-started.md
+++ b/docs/handbook/back-end/getting-started.md
@@ -1,1 +1,243 @@
+# Back End: Getting Started
+
+This guide sets up `educado-api` for local development. The API is a Node.js 20 + Express 5 + TypeScript service
+backed by PostgreSQL, Redis and MinIO.
+
+For the deployed environment and the full environment variable reference, see
+[Deployment & Infrastructure](../../development/technical/deployment.md). For the system design, see
+[System Architecture](../../development/technical/architecture.md).
+
 ## Prerequisites
+
+- **Node.js 20 or newer.** The project declares `engines.node >= 20`. Install it with
+  [nvm](https://github.com/nvm-sh/nvm) (macOS/Linux) or [nvm-windows](https://github.com/coreybutler/nvm-windows).
+- **Docker and the Compose plugin.** Required: the local database, cache and object storage all run in containers.
+- **Git**, ideally with SSH authentication configured. See the
+  [GitHub docs](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent).
+- A REST client (Postman, Insomnia, `curl`) or just the built in Swagger UI.
+
+## Clone the repository
+
+```shell
+git clone git@github.com:ErasmusEgalitarian/educado-api.git
+cd educado-api
+```
+
+## Start the local infrastructure
+
+```shell
+docker compose up -d
+```
+
+!!! important
+
+    Compose starts **only the infrastructure**, not the API. The services it brings up are:
+
+    | Service        | Container              | Host port                        | Purpose                                  |
+    | -------------- | ---------------------- | -------------------------------- | ---------------------------------------- |
+    | `postgres`   | `educado-postgres`   | `5431` (container 5432)        | Database `educado_dev`                 |
+    | `redis`      | `educado-redis`      | `6380` (container 6379)        | BullMQ queue backend                     |
+    | `minio`      | `educado-minio`      | `9002` API, `9003` console   | S3 compatible object storage             |
+    | `minio-setup` | `educado-minio-setup` | none                            | One shot job that creates the `educado-media` bucket and exits |
+
+    The API itself runs on the host with `npm run dev`, and the email worker with `npm run worker:email`.
+
+The `minio-setup` container is expected to exit after it finishes: a `Bucket educado-media ready` line in its logs
+followed by `Exited (0)` means success, not a failure.
+
+Default local credentials: PostgreSQL `educado` / `educado`, MinIO `minioadmin` / `minioadmin`. The MinIO
+console is at [http://localhost:9003](http://localhost:9003).
+
+To check the containers:
+
+```shell
+docker compose ps
+docker compose logs -f postgres
+```
+
+## Install dependencies
+
+```shell
+npm install
+```
+
+Run it again whenever you switch branches or pull changes that touch `package.json` or `package-lock.json`.
+
+## Environment variables
+
+Copy the template and adjust it:
+
+```shell
+cp .env.example .env
+```
+
+A working local `.env` looks like this:
+
+```dotenv
+NODE_ENV=development
+PORT=5001
+
+POSTGRES_URI_DEV=postgresql://educado:educado@localhost:5431/educado_dev
+
+FRONTEND_ORIGIN=http://localhost:3000,http://127.0.0.1:3000,http://localhost:5173,http://127.0.0.1:5173
+ACCESS_TOKEN_SECRET=replace-with-a-strong-secret
+
+S3_ENDPOINT=http://localhost:9002
+S3_REGION=us-east-1
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=educado-media
+
+EMAIL_API_KEY=
+EMAIL_FROM=noreply@example.com
+
+REDIS_HOST=localhost
+REDIS_PORT=6380
+```
+
+!!! warning "The ports in `.env.example` do not all match `docker-compose.yml`"
+
+    `.env.example` ships with `S3_ENDPOINT=http://localhost:9000` and `REDIS_PORT=6379`, which are the
+    **container** ports. Compose publishes them on the host as **9002** and **6380** to avoid clashing with other
+    local services. Use the host ports in your `.env`, as shown above. PostgreSQL is already correct in the
+    template (`5431`).
+
+Generate a real secret with:
+
+```shell
+openssl rand -base64 48
+```
+
+Never commit `.env`.
+
+## Run the API
+
+```shell
+npm run dev
+```
+
+The script forces `NODE_ENV=development` and runs `src/index.ts` through nodemon, so it reloads on save. On a
+successful start you should see the PostgreSQL connection message followed by `Server is running on port: 5001`.
+
+Then open the interactive contract at [http://localhost:5001/docs/](http://localhost:5001/docs/). Swagger is the
+canonical description of every request and response shape.
+
+In development `sequelize.sync()` runs with `alter: true`, so model changes are reflected in the local database on
+restart. There is no separate migration step.
+
+### Seed data
+
+To populate the database with sample courses:
+
+```shell
+npm run seed
+```
+
+## Run the email worker
+
+Email delivery is asynchronous: use cases enqueue jobs on a BullMQ queue backed by Redis, and a separate process sends
+them through Resend. In a second terminal:
+
+```shell
+npm run worker:email
+```
+
+It prints `Email worker running` and stays in the foreground. Without it, verification and password reset emails are
+enqueued but never delivered. Requests still succeed, which makes the symptom easy to misread.
+
+Delivery also requires a valid `EMAIL_API_KEY`. With an empty key you can still exercise the queue, but Resend will
+reject the send.
+
+## Build and run the compiled output
+
+```shell
+npm run build   # tsc, output in build/
+npm start       # node build/index.js
+```
+
+The worker's compiled entrypoint is `node build/workers/email-worker.js`. These are the two commands used in the
+deployed environment.
+
+## Tests
+
+```shell
+npm test              # Jest
+npm run test:watch    # watch mode
+npm run test:coverage # coverage report
+```
+
+Tests live in `__tests__` directories next to the use cases they cover, under `src/application`, and HTTP level
+tests use `supertest`.
+
+## Linting
+
+```shell
+npm run lint
+npm run lint:fix
+```
+
+## Troubleshooting
+
+### The API starts and immediately exits
+
+Symptom: `Unable to connect to the database`, then `Failed to initialize database`, then the process exits. If a
+supervisor is restarting it, this looks like a crash loop.
+
+Cause: `src/config/database.ts` chooses the connection string based on `NODE_ENV`:
+
+```ts
+const isProd = () => process.env.NODE_ENV === 'production'
+const postgresUri = isProd() ? process.env.POSTGRES_URI : process.env.POSTGRES_URI_DEV
+```
+
+The value must be **exactly** `production` for `POSTGRES_URI` to be read. Anything else, including `staging`,
+falls back to `POSTGRES_URI_DEV`. In a deployed environment that variable usually does not exist, so Sequelize gets an
+empty connection string, `testDatabaseConnection()` throws, and `initializeDatabase()` calls `process.exit(1)`.
+
+Fix: set `NODE_ENV=production` and provide `POSTGRES_URI` in deployed environments; set `NODE_ENV=development`
+and provide `POSTGRES_URI_DEV` locally. Do not invent a third value.
+
+Locally, also check that Compose is up and that the port in `POSTGRES_URI_DEV` is `5431`, not `5432`.
+
+### Emails are never delivered / Redis errors
+
+Symptoms: `NOAUTH Authentication required`, or jobs pile up in the queue and nothing is sent.
+
+`src/infrastructure/queue/redis.ts` builds the connection from `REDIS_HOST`, `REDIS_PORT` and
+`REDIS_PASSWORD`, and `REDIS_PASSWORD` has **no default**:
+
+```ts
+const redisPassword = process.env.REDIS_PASSWORD ?? undefined
+```
+
+- Local Compose Redis has **no** password, so leave `REDIS_PASSWORD` unset and point `REDIS_PORT` at `6380`.
+- Any Redis instance that requires authentication (including the deployed one) needs `REDIS_PASSWORD` set, or every
+  queue command is rejected.
+
+Also confirm the worker process is actually running: the API alone only enqueues.
+
+### `ECONNREFUSED` when uploading media
+
+The S3 endpoint is wrong. Compose publishes MinIO on host port **9002**, not 9000. Check `S3_ENDPOINT` and that the
+`educado-media` bucket exists (the `minio-setup` container creates it; re-run `docker compose up -d` if the
+volume was wiped).
+
+### `500 MISSING_ACCESS_TOKEN_SECRET` on authenticated routes
+
+`ACCESS_TOKEN_SECRET` is missing or empty in `.env`. Set it and restart the API.
+
+### CORS errors from the web or mobile client
+
+Outside production the API allows every origin, so a CORS error locally usually means `NODE_ENV` is set to
+`production` by mistake. In production, add the client origin to the comma separated `FRONTEND_ORIGIN` list.
+
+### Port already in use
+
+Change `PORT` in `.env`, or find the offending process. The Compose host ports (5431, 6380, 9002, 9003) were chosen
+to avoid the usual defaults, so a clash there normally means a previous Educado stack is still running:
+
+```shell
+docker compose down
+```
+
+Add `-v` to also drop the volumes and start from an empty database.

--- a/docs/handbook/back-end/getting-started.md
+++ b/docs/handbook/back-end/getting-started.md
@@ -119,6 +119,27 @@ npm run dev
 The script forces `NODE_ENV=development` and runs `src/index.ts` through nodemon, so it reloads on save. On a
 successful start you should see the PostgreSQL connection message followed by `Server is running on port: 5001`.
 
+!!! warning "Windows: `npm run dev` does not work in cmd or PowerShell"
+
+    The script is written as an inline environment assignment:
+
+    ```json
+    "dev": "NODE_ENV=development nodemon src/index.ts"
+    ```
+
+    That syntax is POSIX shell only. Windows `cmd` reports `'NODE_ENV' is not recognized as an internal or external
+    command`, and PowerShell fails in its own way, because neither treats `VAR=value command` as an assignment.
+
+    Work around it by running the project from **WSL** or **Git Bash**, which is the recommended setup, or by
+    setting the variable separately for the session and calling nodemon directly:
+
+    ```powershell
+    $env:NODE_ENV = "development"; npx nodemon src/index.ts
+    ```
+
+    Do not "fix" this by dropping `NODE_ENV`: without it the API falls back to the non production branch anyway, but
+    other scripts and the deployed environment rely on the value being explicit.
+
 Then open the interactive contract at [http://localhost:5001/docs/](http://localhost:5001/docs/). Swagger is the
 canonical description of every request and response shape.
 
@@ -166,8 +187,19 @@ npm run test:watch    # watch mode
 npm run test:coverage # coverage report
 ```
 
-Tests live in `__tests__` directories next to the use cases they cover, under `src/application`, and HTTP level
-tests use `supertest`.
+Tests live in `__tests__` directories next to the code they cover. Most of them sit under `src/application`, one
+per use case module (`courses`, `enrollment`, `gamification`, `registration`, `reviews`, `student-progress`,
+`verification` and so on, plus `application/email/templates`), but they are not limited to that layer:
+
+| Location                                  | Covers                                          |
+| ----------------------------------------- | ----------------------------------------------- |
+| `src/application/*/__tests__`           | Use cases, one directory per module.            |
+| `src/infrastructure/security/__tests__` | Hashing and token primitives.                   |
+| `src/infrastructure/storage/s3/__tests__` | The S3 client, including endpoint resolution and retry behaviour. |
+| `src/interface/http/middlewares/__tests__` | HTTP middlewares such as `requireRole`.      |
+
+HTTP level tests use `supertest`. When you touch code outside `src/application`, look for the sibling `__tests__`
+directory there rather than assuming the coverage lives with the use cases.
 
 ## Linting
 
@@ -224,7 +256,51 @@ volume was wiped).
 
 ### `500 MISSING_ACCESS_TOKEN_SECRET` on authenticated routes
 
-`ACCESS_TOKEN_SECRET` is missing or empty in `.env`. Set it and restart the API.
+This error only happens with `NODE_ENV=production`. If you are seeing it locally, the real problem is that
+`NODE_ENV` is set to `production` by mistake, not that the secret is missing.
+
+`src/config/jwt.ts:13-21` resolves the signing secret in three steps:
+
+```ts
+const configuredSecret =
+  process.env.ACCESS_TOKEN_SECRET ?? process.env.JWT_SECRET
+
+if (configuredSecret && configuredSecret.trim() !== '') {
+  return configuredSecret
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  // warns once, then:
+  return 'dev-insecure-secret-change-me'
+}
+
+throw new AppError(500, { code: 'MISSING_ACCESS_TOKEN_SECRET' })
+```
+
+So:
+
+- **Production** (`NODE_ENV=production`): a missing or blank secret throws `500 MISSING_ACCESS_TOKEN_SECRET` on
+  every route that signs or verifies a token. Set `ACCESS_TOKEN_SECRET` (or its alias `JWT_SECRET`) and restart.
+- **Anywhere else**, including local development: nothing is thrown. The API logs a single warning,
+  `[auth] ACCESS_TOKEN_SECRET/JWT_SECRET não configurado; usando segredo temporário de desenvolvimento.`, and falls
+  back to the hardcoded value `'dev-insecure-secret-change-me'`. Authentication keeps working.
+
+!!! danger "The development fallback is easy to miss"
+
+    The warning is emitted **once per process**, guarded by a module level flag, so it scrolls past on the very first
+    authenticated request and never appears again. Nothing else signals the fallback.
+
+    Consequences worth knowing:
+
+    - Every developer running without the variable shares the same publicly known signing key, so a token minted on
+      one machine is valid on any other one running in the same state.
+    - The secret is in the repository. Any environment that is not exactly `NODE_ENV=production` and is reachable
+      by someone else is effectively unauthenticated.
+    - An environment intended to be production but misconfigured (`staging`, empty, unset) will not fail loudly here:
+      it will quietly issue tokens signed with the hardcoded key. Note that `NODE_ENV` also drives the database
+      selection, so that misconfiguration usually shows up as a crash loop first.
+
+    Set `ACCESS_TOKEN_SECRET` in your local `.env` anyway. Generate one with `openssl rand -base64 48`.
 
 ### CORS errors from the web or mobile client
 

--- a/docs/handbook/web/getting-started.md
+++ b/docs/handbook/web/getting-started.md
@@ -111,8 +111,34 @@ src/
     types/                shared types
 ```
 
-Each feature directory follows the same shape: `api/` for HTTP calls, `pages/` for screens,
-`components/` for reusable pieces and `styles/` for CSS.
+Feature directories share a vocabulary, not a fixed shape. The conventional meaning is `api/` for HTTP calls,
+`pages/` for screens, `components/` for reusable pieces and `styles/` for CSS, but only `pages/` and `styles/`
+exist in every feature. The rest are there when the feature needs them:
+
+| Feature       | `api/` | `components/` | `pages/` | `styles/` | Extra                   |
+| ------------- | :------: | :-------------: | :--------: | :---------: | ----------------------- |
+| `admin`     | yes    | no            | yes      | yes       |                         |
+| `auth`      | yes    | yes           | yes      | yes       |                         |
+| `courses`   | yes    | no            | yes      | yes       | `editor/`, `model/` |
+| `dashboard` | no     | no            | yes      | yes       |                         |
+| `media`     | yes    | yes           | yes      | yes       | `services/`           |
+| `public`    | no     | yes           | yes      | yes       |                         |
+| `student`   | yes    | yes           | yes      | yes       |                         |
+
+The departures are deliberate:
+
+- `courses` is the biggest feature and splits differently: `editor/` holds the course editor and `model/` the
+  domain types (`course.types.ts`) it works on. It has no `components/`.
+- `media` adds `services/upload-manager.ts`, which orchestrates the chunked upload flow on top of
+  `api/media.api.ts`. That is logic that fits neither a thin API module nor a page.
+- `dashboard` is a single static page with its stylesheet and nothing else, so it has no `api/` and no
+  `components/`.
+- `public` has no `api/` of its own: the one page that needs data imports the shared client directly
+  (`import { api } from '@/shared/api/http'`).
+- Most features expose an `index.ts` barrel; `admin` and `dashboard` do not.
+
+When adding a feature, reuse the vocabulary above and create only the directories you actually need. Do not add
+empty `api/` or `components/` folders for the sake of symmetry.
 
 The `@` alias resolves to `src/`, configured both in `vite.config.ts` and `tsconfig.json`.
 

--- a/docs/handbook/web/getting-started.md
+++ b/docs/handbook/web/getting-started.md
@@ -1,0 +1,147 @@
+# Web: Getting Started
+
+This guide sets up `educado-web` for local development. The web application is the interface used by content
+creators and administrators.
+
+!!! note "No UI framework"
+
+    `educado-web` is **plain TypeScript** bundled by Vite. There is no Vue, React or Angular. Pages are functions
+    that build DOM nodes, and navigation goes through a small hand written router in `src/app/router.ts` backed by
+    the History API. Do not add a framework without discussing it with the team first.
+
+Related documents:
+
+- [Back End Getting Started](../back-end/getting-started.md), needed because the web app talks to a running API.
+- [API Documentation](../../development/technical/api.md) and the Swagger UI.
+- [Deployment & Infrastructure](../../development/technical/deployment.md) for how the app is built and served in
+  production.
+
+## Prerequisites
+
+- **Node.js 20 or newer** ([nvm](https://github.com/nvm-sh/nvm) or
+  [nvm-windows](https://github.com/coreybutler/nvm-windows)).
+- **Git**.
+- A running Educado API, either locally on port 5001 or the deployed one.
+
+## Clone and install
+
+```shell
+git clone git@github.com:ErasmusEgalitarian/educado-web.git
+cd educado-web
+npm install
+```
+
+## Environment variables
+
+The only variable the app reads is `VITE_API_URL`, the base URL of the API. Create a `.env` in the project root:
+
+```dotenv
+VITE_API_URL=http://localhost:5001
+```
+
+If you want to work against the deployed backend instead:
+
+```dotenv
+VITE_API_URL=https://api-educado.tominho.com
+```
+
+!!! danger
+
+    Pointing at the deployed API means you are reading and writing **live data** shared with everyone else. Prefer a
+    local API while developing.
+
+When `VITE_API_URL` is unset, `src/shared/api/http.ts` falls back to `http://localhost:5001`.
+
+!!! important "Vite variables are compiled in"
+
+    `import.meta.env.VITE_API_URL` is replaced at build time. Changing the value requires restarting the dev server
+    (or rebuilding the image in production), not just reloading the page.
+
+## Run the dev server
+
+```shell
+npm run dev
+```
+
+Vite serves the app at [http://localhost:3000](http://localhost:3000) (the port is pinned in `vite.config.ts`).
+
+The dev server also proxies `/api` to `http://localhost:5001`, stripping the prefix. Note that the API client uses
+`VITE_API_URL` directly, so the proxy is only a convenience for requests written against a relative `/api` path.
+
+Make sure the API is up before you log in:
+
+```shell
+# in the educado-api checkout
+docker compose up -d
+npm run dev
+```
+
+## Build and preview
+
+```shell
+npm run build     # tsc type check, then vite build into dist/
+npm run preview   # serve the production bundle locally
+```
+
+`npm run build` runs `tsc` first, so a type error fails the build. There is no separate type check script.
+
+## Project structure
+
+```text
+src/
+  main.ts                 entrypoint, mounts the app and wires the router
+  app/
+    router.ts             History API router (navigate, replace, subscribe)
+    routes/               route table
+    pages/                shared top level pages
+    styles/globals.css    global styles
+  features/
+    admin/                user and institution administration
+    auth/                 login, registration, password reset, profile
+    courses/              course editor and management
+    dashboard/            creator dashboard
+    media/                upload and media library
+    public/               landing and public pages
+    student/              student facing pages
+  shared/
+    api/http.ts           fetch wrapper, ApiError, base URL
+    api/auth-session.ts   access token storage
+    i18n/                 pt-BR and en-US translations
+    ui/                   toast, loader, language switcher
+    types/                shared types
+```
+
+Each feature directory follows the same shape: `api/` for HTTP calls, `pages/` for screens,
+`components/` for reusable pieces and `styles/` for CSS.
+
+The `@` alias resolves to `src/`, configured both in `vite.config.ts` and `tsconfig.json`.
+
+## Talking to the API
+
+Use the wrapper in `src/shared/api/http.ts` instead of calling `fetch` directly. It prefixes the base URL,
+attaches the bearer token when `auth: true`, parses the JSON body, and throws an `ApiError` carrying `status`,
+`code` and `fieldErrors` for failed responses. Clearing the session on `401` is handled there too.
+
+## Internationalisation
+
+Copy lives in `src/shared/i18n/index.ts` as a nested translation tree with `pt-BR` and `en-US`. The selected
+language is persisted in local storage under `educado.language`. Add new strings to **both** languages: a missing
+key falls back to the raw key path, which is visible to the user.
+
+## Production build
+
+Production uses the multi stage `Dockerfile`: Node 20 builds the bundle, nginx serves `dist/` with an SPA
+fallback. `VITE_API_URL` is passed as a **build argument**, so changing the API URL requires a rebuild. Details in
+[Deployment & Infrastructure](../../development/technical/deployment.md).
+
+## Troubleshooting
+
+| Symptom                                        | Likely cause                                                                                      |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Every request fails with a network error       | The API is not running, or `VITE_API_URL` points at the wrong port. The API default is 5001.     |
+| CORS error against a local API                 | The API has `NODE_ENV=production` locally. Outside production it allows every origin.            |
+| CORS error against the deployed API            | Your origin is not in the API `FRONTEND_ORIGIN` allowlist.                                      |
+| Logged out on every request                    | The token expired or `ACCESS_TOKEN_SECRET` changed on the API side. Log in again.               |
+| Changing `.env` has no effect                | Restart the dev server. Vite inlines the variable at build time.                                   |
+| Images or videos do not load                   | Media streaming needs a valid token in the query string, and MinIO must be reachable by the API.   |
+| A route renders a blank page                   | Check the browser console: the router is minimal and does not catch rendering errors for you.      |

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ overview to technical and configuration details.
 | [API Specification](development/technical/api.md)                         | API definitions and guidelines       |
 | [System Architecture](development/technical/architecture.md)              | High-level system design             |
 | [Database Schema](development/technical/database-schema.md)               | Database models and relationships    |
+| [Deployment & Infrastructure](development/technical/deployment.md)        | Runtime topology, hosting and environment variables |
 | [Development Lifecycle](development/lifecycle.md)                         | Stages of the development process    |
 | [Tools & Dependencies](development/tools.md)                              | List of required tools and libraries |
 
@@ -54,6 +55,7 @@ overview to technical and configuration details.
 |---------------------------------------------------|-------------------------------------------------|
 | [Mobile](handbook/mobile/getting-started.md)      | How to set up the mobile app for development    |
 | [Back End](handbook/back-end/getting-started.md)  | How to set up the back end for development      |
+| [Web](handbook/web/getting-started.md)            | How to set up the web application for development |
 | [Documentation](handbook/docs/getting-started.md) | How to set up the documentation for development |
 
 ### 🔗 References

--- a/docs/product/overview.md
+++ b/docs/product/overview.md
@@ -45,12 +45,15 @@ Educado is currently in active development by international teams and aims to pr
 
 ## Technical Specifications
 
-| Attribute             | Details                                                                                                 |
-| --------------------- | ------------------------------------------------------------------------------------------------------- |
-| **Platform**          | Web for creators/admins; Mobile app (Android/iOS) for students.                                         |
-| **Technology Stack**  | Frontend: React Native (mobile) / Vue.js (web) <br> Backend: Node.js (NestJS) <br> Database: PostgreSQL |
-| **Hosting**           | Cloud-native, containerized, deployable on AWS/GCP/Azure.                                               |
-| **Supported Devices** | Android (priority), iOS, Web browsers (desktop).                                                        |
+| Attribute             | Details                                                                                                                                    |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Platform**          | Web for creators/admins; mobile app (Android first) for students.                                                                          |
+| **Technology Stack**  | Mobile: Expo SDK 56 + React Native <br> Web: Vite + TypeScript, no UI framework, served by nginx <br> Backend: Node.js 20 + Express 5 + TypeScript |
+| **Data Stores**       | PostgreSQL 16 (Sequelize), Redis 7.2 (BullMQ queue), MinIO for S3 compatible media storage.                                                |
+| **Integrations**      | Resend for transactional email; JWT for authentication.                                                                                    |
+| **Hosting**           | Containerised and deployed with Coolify 4.3.1 on the project's own VPS, behind Traefik. See [Deployment & Infrastructure](../development/technical/deployment.md). |
+| **Public URLs**       | Web: [https://educado.tominho.com](https://educado.tominho.com) <br> API: [https://api-educado.tominho.com](https://api-educado.tominho.com) |
+| **Supported Devices** | Android (priority), web browsers (desktop). iOS is not part of the current scope.                                                          |
 
 ---
 

--- a/docs/product/research/strapi-evaluation.md
+++ b/docs/product/research/strapi-evaluation.md
@@ -86,6 +86,16 @@ Integrating Strapi introduces a service-oriented architecture. The infrastructur
 
 ![architecture](../../assets/strapi/architecture.svg)
 
+!!! warning "This diagram is historical and does not reflect the current stack"
+
+    The diagram above was drawn during the evaluation and is kept as a record of it. Three of its boxes are labelled
+    **MongoDB**, which was never the database of the implemented system: Educado runs on **PostgreSQL 16** through
+    Sequelize. Read every MongoDB box as "the platform database".
+
+    The labels were deliberately left untouched so the artifact still matches the analysis it documents. For the
+    stack actually in use, see [System Architecture](../../development/technical/architecture.md) and
+    [Database Schema](../../development/technical/database-schema.md).
+
 
 ### Solution 1: Centralized Proxy via NodeJS
 
@@ -119,7 +129,7 @@ In this model, each frontend communicates directly with the service it needs. Th
 | Pros                                                                                                                | Cons                                                                                                             |
 | :------------------------------------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------------------------------- |
 | ✅ **Accelerated Development:** Leverages a fully functional backend designed for content management.               | ❌ **New Dependency:** Adds a new, large system to learn, manage, and maintain.                                  |
-| ✅ **Rich Feature Set:** Includes media library, draft/publish, roles, i18n, etc., out-of-the-box.                  | ❌ **Additional Database:** Requires a relational database (Postgres) in addition to our existing MongoDB.       |
+| ✅ **Rich Feature Set:** Includes media library, draft/publish, roles, i18n, etc., out-of-the-box.                  | ❌ **Additional Database:** Requires its own database instance, separate from the one already backing the platform, so content and application data end up split across two stores to keep in sync and back up. |
 | ✅ **Excellent Developer Tooling:** OpenAPI/Swagger support and type-safe client generation streamline integration. | ❌ **Potential Overkill:** The platform has more features than we may immediately need.                          |
 | ✅ **Flexible Data Modeling:** The Content-Type Builder is powerful and intuitive.                                  | ❌ **Custom Frontend Required:** The native admin UI is not sufficient for our end-user (content creator) goals. |
 | ✅ **Docker-Based Deployment:** Integrates easily with our existing infrastructure.                                 |                                                                                                                  |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
           - API Documentation: development/technical/api.md
           - System Architecture: development/technical/architecture.md
           - Database Schema: development/technical/database-schema.md
+          - Deployment & Infrastructure: development/technical/deployment.md
           - Tools & Dependencies: development/tools.md
   - Developer Handbook:
       - Mobile:
@@ -131,6 +132,8 @@ nav:
           - FAQ: handbook/mobile/faq.md
       - Back End:
           - Getting Started: handbook/back-end/getting-started.md
+      - Web:
+          - Getting Started: handbook/web/getting-started.md
       - Documentation:
           - Getting Started: handbook/docs/getting-started.md
           - Workflow: handbook/docs/workflow.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "educado-docs"
-version = "2.6.2"
+version = "2.7.0"
 description = "Official documentation for the Educado project"
 readme = "README.md"
 authors = [
     { name = "Martin Kedmenec <70742985+audio-engineer@users.noreply.github.com>" },
     { name = "LucasGSAntunes <190091681@aluno.unb.br>" }
 ]
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 dependencies = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.6.21",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Martin Kedmenec <70742985+audio-engineer@users.noreply.github.com>" },
     { name = "LucasGSAntunes <190091681@aluno.unb.br>" }
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 dependencies = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.6.21",


### PR DESCRIPTION
Atualiza a documentacao tecnica, que estava descrevendo um sistema diferente do que existe.

## Corrigido
- `architecture.md`: descrevia **MongoDB, Vue.js** e um dominio de "doctors and administrators", com modelos User/Document/Topic. Era conteudo de outro projeto. Reescrito para a arquitetura real.
- `api.md`: base URL era `https://api.educado.com`, que nao existe. Agora `https://api-educado.tominho.com`, com a lista de rotas alinhada ao `src/index.ts`.
- `tools.md`: listava Vue.js, Jenkins e New Relic, nenhum em uso.
- `product/overview.md`: dizia NestJS e deploy em AWS/GCP/Azure.

## Adicionado
- `handbook/back-end/getting-started.md`: tinha uma linha vazia.
- `handbook/web/getting-started.md`: nao existia.
- `technical/deployment.md`: topologia Coolify, tabela completa de variaveis e a armadilha do `NODE_ENV`, que precisa ser exatamente `production` senao a API entra em loop de crash.

CHANGELOG e pyproject bumpados para 2.7.0 (o CI exige). `mkdocs build --strict` passa limpo.